### PR TITLE
Add testing Ruby 2.7 for Katello

### DIFF
--- a/theforeman.org/pipelines/test/testKatello.groovy
+++ b/theforeman.org/pipelines/test/testKatello.groovy
@@ -1,175 +1,158 @@
 def katello_versions = [
     'master': [
         'foreman': 'develop',
-        'ruby': '2.5',
+        'ruby': ['2.5', '2.7']
     ],
     'KATELLO-4.0': [
         'foreman': '2.4-stable',
-        'ruby': '2.5'
+        'ruby': ['2.5']
     ],
     'KATELLO-3.18': [
         'foreman': '2.3-stable',
-        'ruby': '2.5'
+        'ruby': ['2.5']
     ],
     'KATELLO-3.17': [
         'foreman': '2.2-stable',
-        'ruby': '2.5'
+        'ruby': ['2.5']
     ],
 ]
 
-def ruby = katello_versions[ghprbTargetBranch]['ruby']
+def ruby_versions = katello_versions[ghprbTargetBranch]['ruby']
 def foreman_branch = katello_versions[ghprbTargetBranch]['foreman']
 
 pipeline {
+    agent none
+
     options {
         timestamps()
         timeout(time: 3, unit: 'HOURS')
         ansiColor('xterm')
     }
 
-    agent { label 'fast' }
-
     stages {
-        stage('Setup Git Repos') {
-            steps {
-                deleteDir()
-                ghprb_git_checkout()
-
-                dir('foreman') {
-                   git url: "https://github.com/theforeman/foreman", branch: foreman_branch, poll: false
-                }
-            }
-        }
-        stage("Setup RVM") {
-            steps {
-
-                configureRVM(ruby)
-
-            }
-        }
-        stage('Configure Environment') {
-            steps {
-
-                dir('foreman') {
-                    addGem()
-                    databaseFile(gemset())
-                }
-
-            }
-        }
-        stage('Configure Database') {
-            steps {
-
-                dir('foreman') {
-                    configureDatabase(ruby)
-                }
-
-            }
-        }
-        stage('Install Foreman npm packages') {
-            steps {
-                dir('foreman') {
-                    withRVM(["bundle exec npm install"], ruby)
-                }
-            }
-        }
-        stage('Run Tests') {
-            parallel {
-                stage('tests') {
-                    steps {
-                        dir('foreman') {
-                            withRVM(['bundle exec rake jenkins:katello TESTOPTS="-v" --trace'], ruby)
-                        }
+        stage('Test') {
+            matrix {
+                agent { label 'fast' }
+                axes {
+                    axis {
+                        name 'ruby'
+                        values '2.5', '2.7'
                     }
                 }
-                stage('rubocop') {
-                    steps {
-                        dir('foreman') {
-                            withRVM(['bundle exec rake katello:rubocop TESTOPTS="-v" --trace'], ruby)
-                        }
+                when {
+                    expression {
+                        ruby_versions.contains(env.ruby)
                     }
                 }
-                stage('react-ui') {
-                    when {
-                        expression { fileExists('package.json') }
-                    }
-                    steps {
-                        sh "npm install"
-                        sh 'npm test'
-                    }
-                }
-                stage('angular-ui') {
-                    steps {
-                        script {
-                            if (!fileExists('engines/bastion')) {
-                                dir('foreman') {
-                                    withRVM(['bundle show bastion > bastion-version'], ruby)
+                stages {
+                    stage('Setup Git Repos') {
+                        steps {
+                            ghprb_git_checkout()
 
-                                    script {
-                                        bastion_install = readFile('bastion-version')
-                                        bastion_version = bastion_install.split('bastion-')[1]
-                                        echo bastion_install
-                                        echo bastion_version
-                                    }
-                                }
-
-                                sh "cp -rf \$(cat foreman/bastion-version) engines/bastion_katello/bastion-${bastion_version}"
-                                dir('engines/bastion_katello') {
-                                    sh "npm install bastion-${bastion_version}"
-                                    sh "grunt ci"
-                                }
-                            } else {
-                                dir('engines/bastion') {
-                                    sh "npm install"
-                                    sh "grunt ci"
-                                }
-                                dir('engines/bastion_katello') {
-                                    sh "npm install"
-                                    sh "grunt ci"
-                                }
+                            dir('foreman') {
+                               git url: "https://github.com/theforeman/foreman", branch: foreman_branch, poll: false
                             }
                         }
                     }
-                }
-                stage('assets-precompile') {
-                    steps {
-                        dir('foreman') {
-                            withRVM(['bundle exec rake plugin:assets:precompile[katello] RAILS_ENV=production DATABASE_URL=nulldb://nohost --trace'], ruby)
+                    stage("Setup RVM") {
+                        steps {
+
+                            configureRVM(ruby)
+
+                        }
+                    }
+                    stage('Configure Environment') {
+                        steps {
+
+                            dir('foreman') {
+                                addGem()
+                                databaseFile(gemset())
+                            }
+
+                        }
+                    }
+                    stage('Configure Database') {
+                        steps {
+
+                            dir('foreman') {
+                                configureDatabase(ruby)
+                            }
+
+                        }
+                    }
+                    stage('rubocop') {
+                        steps {
+                            dir('foreman') {
+                                withRVM(['bundle exec rake katello:rubocop TESTOPTS="-v" --trace'], ruby)
+                            }
+                        }
+                    }
+                    stage('Install Foreman npm packages') {
+                        steps {
+                            dir('foreman') {
+                                withRVM(["bundle exec npm install"], ruby)
+                            }
+                        }
+                    }
+                    stage('react-ui') {
+                        steps {
+                            sh "npm install"
+                            sh 'npm test'
+                        }
+                    }
+                    stage('angular-ui') {
+                        steps {
+                            dir('engines/bastion') {
+                                sh "npm install"
+                                sh "grunt ci"
+                            }
+                            dir('engines/bastion_katello') {
+                                sh "npm install"
+                                sh "grunt ci"
+                            }
+                        }
+                    }
+                    stage('tests') {
+                        steps {
+                            dir('foreman') {
+                                withRVM(['bundle exec rake jenkins:katello TESTOPTS="-v" --trace'], ruby)
+                            }
+                        }
+                    }
+                    stage('assets-precompile') {
+                        steps {
+                            dir('foreman') {
+                                withRVM(['bundle exec rake plugin:assets:precompile[katello] RAILS_ENV=production DATABASE_URL=nulldb://nohost --trace'], ruby)
+                            }
+                        }
+                    }
+                    stage('Test db:seed') {
+                        steps {
+
+                            dir('foreman') {
+
+                                withRVM(['bundle exec rake db:drop RAILS_ENV=test || true'], ruby)
+                                withRVM(['bundle exec rake db:create RAILS_ENV=test'], ruby)
+                                withRVM(['bundle exec rake db:migrate RAILS_ENV=test'], ruby)
+                                withRVM(['bundle exec rake db:seed RAILS_ENV=test'], ruby)
+
+                            }
+
                         }
                     }
                 }
-            }
-            post {
-                always {
-                    dir('foreman') {
-                        archiveArtifacts artifacts: "log/test.log"
-                        junit keepLongStdio: true, testResults: 'jenkins/reports/unit/*.xml'
+                post {
+                    always {
+                        dir('foreman') {
+                            archiveArtifacts artifacts: "log/test.log"
+                            junit keepLongStdio: true, testResults: 'jenkins/reports/unit/*.xml'
+                            cleanup(ruby)
+                        }
+                        deleteDir()
                     }
                 }
             }
         }
-        stage('Test db:seed') {
-            steps {
-
-                dir('foreman') {
-
-                    withRVM(['bundle exec rake db:drop RAILS_ENV=test || true'], ruby)
-                    withRVM(['bundle exec rake db:create RAILS_ENV=test'], ruby)
-                    withRVM(['bundle exec rake db:migrate RAILS_ENV=test'], ruby)
-                    withRVM(['bundle exec rake db:seed RAILS_ENV=test'], ruby)
-
-                }
-
-            }
-        }
     }
 
-    post {
-        always {
-            dir('foreman') {
-                cleanup(ruby)
-            }
-            deleteDir()
-        }
-    }
 }

--- a/theforeman.org/yaml/jobs/tests/katello-pr-test.yaml
+++ b/theforeman.org/yaml/jobs/tests/katello-pr-test.yaml
@@ -16,3 +16,19 @@
         - pipelines/lib/rvm.groovy
         - pipelines/lib/git.groovy
         - pipelines/lib/foreman.groovy
+
+- job:
+    name: katello-pr-test-ehelms
+    project-type: pipeline
+    sandbox: true
+    concurrent: true
+    properties:
+      - github:
+          url: https://github.com/Katello/katello
+      - tfm-pull-request-build-discarder
+    dsl:
+      !include-raw:
+        - pipelines/test/testKatello.groovy
+        - pipelines/lib/rvm.groovy
+        - pipelines/lib/git.groovy
+        - pipelines/lib/foreman.groovy


### PR DESCRIPTION
Changes to a matrix style job for Katello PR testing and drops
the previous parallelism.

After switching packaging we can drop 2.5 for nightly. I have observed that the Ruby 2.7 tests run 15-20 minutes faster than 2.5. I think the previous parallelism was incorrect and not providing any benefit. Further, you cannot nest parallel instead matrix. Talking with Katello team, they are OK going this route for a while and seeing how things perform.