### PR TITLE
Move RVM and directory cleanup to cleanup stage of post

### DIFF
--- a/theforeman.org/pipelines/test/testKatello.groovy
+++ b/theforeman.org/pipelines/test/testKatello.groovy
@@ -134,6 +134,10 @@ pipeline {
                         dir('foreman') {
                             archiveArtifacts artifacts: "log/test.log"
                             junit keepLongStdio: true, testResults: 'jenkins/reports/unit/*.xml'
+                        }
+                    }
+                    cleanup {
+                        dir('foreman') {
                             cleanup(ruby)
                         }
                         deleteDir()


### PR DESCRIPTION
If a step in the always stage of post, such as the junit plugin fails,
the cleanups will not run and result in a dirty workspace. This
can lead to issues th enext time the same job is run on the same
node.