### PR TITLE
correct katello paths

### DIFF
--- a/theforeman.org/pipelines/lib/release.groovy
+++ b/theforeman.org/pipelines/lib/release.groovy
@@ -31,8 +31,8 @@ void push_pulpcore_rpms(version, distro) {
 
 void push_katello_rpms(version, distro) {
     keep_old = version != 'nightly'
-    push_rpms("katello-${version}/katello", "katello/katello", version, distro, keep_old)
-    push_rpms("katello-${version}/candlepin", "katello/candlepin", version, distro, keep_old)
+    push_rpms_direct("katello-${version}/katello/${distro}", "katello/${version}/katello/${distro}", !keep_old, keep_old)
+    push_rpms_direct("katello-${version}/candlepin/${distro}", "katello/${version}/candlepin/${distro}", !keep_old, keep_old)
 }
 
 void mash(collection, version) {

--- a/theforeman.org/pipelines/lib/release.groovy
+++ b/theforeman.org/pipelines/lib/release.groovy
@@ -30,7 +30,8 @@ void push_pulpcore_rpms(version, distro) {
 }
 
 void push_katello_rpms(version, distro) {
-    push_rpms("katello-${version}", "katello", version, distro, true)
+    push_rpms("katello-${version}/katello", "katello/katello", version, distro, true)
+    push_rpms("katello-${version}/candlepin", "katello/candlepin", version, distro, true)
 }
 
 void mash(collection, version) {

--- a/theforeman.org/pipelines/lib/release.groovy
+++ b/theforeman.org/pipelines/lib/release.groovy
@@ -30,8 +30,9 @@ void push_pulpcore_rpms(version, distro) {
 }
 
 void push_katello_rpms(version, distro) {
-    push_rpms("katello-${version}/katello", "katello/katello", version, distro, true)
-    push_rpms("katello-${version}/candlepin", "katello/candlepin", version, distro, true)
+    keep_old = version != 'nightly'
+    push_rpms("katello-${version}/katello", "katello/katello", version, distro, keep_old)
+    push_rpms("katello-${version}/candlepin", "katello/candlepin", version, distro, keep_old)
 }
 
 void mash(collection, version) {


### PR DESCRIPTION
also keep old files only for releases