### PR TITLE
retry cico provisioning with ansible

### DIFF
--- a/centos.org/ansible/provision.yml
+++ b/centos.org/ansible/provision.yml
@@ -9,6 +9,9 @@
         api_key: "{{ api_key }}"
         retry_count: 5
       register: cico_get_data
+      retry: 2
+      delay: 310
+      until: cico_get_data.results is defined
 
     - name: 'Fail if no SSID returned'
       fail:


### PR DESCRIPTION
ci.centos.org has a 6 nodes per 5 minutes provisioning limit,

so let's retry after 310 seconds (5 min 10 sec)