### PR TITLE
Switch kafo and installer to pure excludes matrix for Puppet and Ruby…

### DIFF
--- a/theforeman.org/pipelines/test/foreman-installer.groovy
+++ b/theforeman.org/pipelines/test/foreman-installer.groovy
@@ -27,7 +27,7 @@ pipeline {
                         }
                         axis {
                             name 'PUPPET_VERSION'
-                            notValues '5.0'
+                            values '5.0'
                         }
                     }
                     exclude {
@@ -37,7 +37,7 @@ pipeline {
                         }
                         axis {
                             name 'PUPPET_VERSION'
-                            notValues '6.0'
+                            values '6.0'
                         }
                     }
                     exclude {
@@ -47,7 +47,7 @@ pipeline {
                         }
                         axis {
                             name 'PUPPET_VERSION'
-                            notValues '7.0'
+                            values '7.0'
                         }
                     }
                 }

--- a/theforeman.org/pipelines/test/kafo.groovy
+++ b/theforeman.org/pipelines/test/kafo.groovy
@@ -26,7 +26,7 @@ pipeline {
                         }
                         axis {
                             name 'PUPPET_VERSION'
-                            notValues '5.0'
+                            values '5.0'
                         }
                     }
                     exclude {
@@ -36,7 +36,7 @@ pipeline {
                         }
                         axis {
                             name 'PUPPET_VERSION'
-                            notValues '6.0'
+                            values '6.0'
                         }
                     }
                     exclude {
@@ -46,7 +46,7 @@ pipeline {
                         }
                         axis {
                             name 'PUPPET_VERSION'
-                            notValues '7.0'
+                            values '7.0'
                         }
                     }
                 }


### PR DESCRIPTION
… versions

The use of notValues for both slots of the matrix created no viable
job configurations. One part would need to be notValues and the other
values in order to work. Given this can be confusing to read, this
opts for a more classic exclusion model pairing up ruby and puppet
versions that should not be tested together explicitly.

Fixes c94c33fb1898600fd499240e932f709d6ccfec74