### PR TITLE
Remove Puppet 5 testing from installer PRs

### DIFF
--- a/theforeman.org/pipelines/test/foreman-installer.groovy
+++ b/theforeman.org/pipelines/test/foreman-installer.groovy
@@ -70,15 +70,12 @@ pipeline {
                     }
                     stage('Test installer configuration') {
                         steps {
-                            script {
-                              install_dir = "${ruby}-${PUPPET_VERSION}"
-                            }
-                            withRVM(["BUNDLE_GEMFILE=Gemfile.${ruby}-${PUPPET_VERSION} bundle exec rake install PREFIX=${install_dir} --trace"], ruby, "${ruby}-${PUPPET_VERSION}")
-                            withRVM(["BUNDLE_GEMFILE=Gemfile.${ruby}-${PUPPET_VERSION} bundle exec ${install_dir}/sbin/foreman-installer --help --scenario foreman --trace"], ruby, "${ruby}-${PUPPET_VERSION}")
-                            withRVM(["BUNDLE_GEMFILE=Gemfile.${ruby}-${PUPPET_VERSION} bundle exec ${install_dir}/sbin/foreman-installer --help --scenario foreman-proxy-content --trace"], ruby, "${ruby}-${PUPPET_VERSION}")
-                            withRVM(["BUNDLE_GEMFILE=Gemfile.${ruby}-${PUPPET_VERSION} bundle exec ${install_dir}/sbin/foreman-installer --help --scenario katello --trace"], ruby, "${ruby}-${PUPPET_VERSION}")
-                            withRVM(["BUNDLE_GEMFILE=Gemfile.${ruby}-${PUPPET_VERSION} bundle exec ${install_dir}/sbin/foreman-proxy-certs-generate --help --trace"], ruby, "${ruby}-${PUPPET_VERSION}")
-                            withRVM(["BUNDLE_GEMFILE=Gemfile.${ruby}-${PUPPET_VERSION} bundle exec ${install_dir}/sbin/foreman-proxy-certs-generate --help|grep -q certs-update-server"], ruby, "${ruby}-${PUPPET_VERSION}")
+                            withRVM(["BUNDLE_GEMFILE=Gemfile.${ruby}-${PUPPET_VERSION} bundle exec rake install PREFIX=${ruby}-${PUPPET_VERSION} --trace"], ruby, "${ruby}-${PUPPET_VERSION}")
+                            withRVM(["BUNDLE_GEMFILE=Gemfile.${ruby}-${PUPPET_VERSION} bundle exec ${ruby}-${PUPPET_VERSION}/sbin/foreman-installer --help --scenario foreman --trace"], ruby, "${ruby}-${PUPPET_VERSION}")
+                            withRVM(["BUNDLE_GEMFILE=Gemfile.${ruby}-${PUPPET_VERSION} bundle exec ${ruby}-${PUPPET_VERSION}/sbin/foreman-installer --help --scenario foreman-proxy-content --trace"], ruby, "${ruby}-${PUPPET_VERSION}")
+                            withRVM(["BUNDLE_GEMFILE=Gemfile.${ruby}-${PUPPET_VERSION} bundle exec ${ruby}-${PUPPET_VERSION}/sbin/foreman-installer --help --scenario katello --trace"], ruby, "${ruby}-${PUPPET_VERSION}")
+                            withRVM(["BUNDLE_GEMFILE=Gemfile.${ruby}-${PUPPET_VERSION} bundle exec ${ruby}-${PUPPET_VERSION}/sbin/foreman-proxy-certs-generate --help --trace"], ruby, "${ruby}-${PUPPET_VERSION}")
+                            withRVM(["BUNDLE_GEMFILE=Gemfile.${ruby}-${PUPPET_VERSION} bundle exec ${ruby}-${PUPPET_VERSION}/sbin/foreman-proxy-certs-generate --help|grep -q certs-update-server"], ruby, "${ruby}-${PUPPET_VERSION}")
                         }
                     }
                 }

--- a/theforeman.org/pipelines/test/foreman-installer.groovy
+++ b/theforeman.org/pipelines/test/foreman-installer.groovy
@@ -12,24 +12,14 @@ pipeline {
                 axes {
                     axis {
                         name 'ruby'
-                        values '2.4', '2.5', '2.7'
+                        values '2.5', '2.7'
                     }
                     axis {
                         name 'PUPPET_VERSION'
-                        values '5.0', '6.0', '7.0'
+                        values '6.0', '7.0'
                     }
                 }
                 excludes {
-                    exclude {
-                        axis {
-                            name 'ruby'
-                            notValues '2.4'
-                        }
-                        axis {
-                            name 'PUPPET_VERSION'
-                            values '5.0'
-                        }
-                    }
                     exclude {
                         axis {
                             name 'ruby'


### PR DESCRIPTION
When Puppet 7 testing was added, so was Puppet 5 testing added.
Puppet 5 testing suffers from issues loading Facter for running
the unit tests and is why it was not previously present.