### PR TITLE
don't clean up jobs that don't have an agent

### DIFF
--- a/theforeman.org/pipelines/release/pipelines/client.groovy
+++ b/theforeman.org/pipelines/release/pipelines/client.groovy
@@ -51,9 +51,4 @@ pipeline {
             }
         }
     }
-    post {
-        cleanup {
-            deleteDir()
-        }
-    }
 }

--- a/theforeman.org/pipelines/release/pipelines/foreman-deb.groovy
+++ b/theforeman.org/pipelines/release/pipelines/foreman-deb.groovy
@@ -33,8 +33,5 @@ pipeline {
         failure {
             notifyDiscourse(env, 'Foreman DEB nightly pipeline failed:', currentBuild.description)
         }
-        cleanup {
-            deleteDir()
-        }
     }
 }

--- a/theforeman.org/pipelines/release/pipelines/foreman-pipeline.groovy
+++ b/theforeman.org/pipelines/release/pipelines/foreman-pipeline.groovy
@@ -75,8 +75,5 @@ pipeline {
           build job: "foreman-plugins-${foreman_version}-rpm-test-pipeline", wait: false
           build job: "foreman-plugins-${foreman_version}-deb-test-pipeline", wait: false
         }
-        cleanup {
-            deleteDir()
-        }
     }
 }

--- a/theforeman.org/pipelines/release/pipelines/foreman-rpm.groovy
+++ b/theforeman.org/pipelines/release/pipelines/foreman-rpm.groovy
@@ -51,9 +51,6 @@ pipeline {
         failure {
             notifyDiscourse(env, 'Foreman RPM nightly pipeline failed:', currentBuild.description)
         }
-        cleanup {
-            deleteDir()
-        }
     }
 }
 

--- a/theforeman.org/pipelines/release/pipelines/katello.groovy
+++ b/theforeman.org/pipelines/release/pipelines/katello.groovy
@@ -56,8 +56,5 @@ pipeline {
         failure {
             notifyDiscourse(env, 'Katello nightly pipeline failed:', currentBuild.description)
         }
-        cleanup {
-            deleteDir()
-        }
     }
 }

--- a/theforeman.org/pipelines/release/pipelines/luna.groovy
+++ b/theforeman.org/pipelines/release/pipelines/luna.groovy
@@ -22,8 +22,5 @@ pipeline {
         failure {
             notifyDiscourse(env, 'Luna nightly pipeline failed:', currentBuild.description)
         }
-        cleanup {
-            deleteDir()
-        }
     }
 }

--- a/theforeman.org/pipelines/release/pipelines/plugins-deb.groovy
+++ b/theforeman.org/pipelines/release/pipelines/plugins-deb.groovy
@@ -24,8 +24,5 @@ pipeline {
         failure {
             notifyDiscourse(env, "Foreman ${foreman_version} Plugins DEB Test pipeline failed:", currentBuild.description)
         }
-        cleanup {
-            deleteDir()
-        }
     }
 }

--- a/theforeman.org/pipelines/release/pipelines/plugins-rpm.groovy
+++ b/theforeman.org/pipelines/release/pipelines/plugins-rpm.groovy
@@ -24,8 +24,5 @@ pipeline {
         failure {
             notifyDiscourse(env, "Foreman ${foreman_version} Plugins RPM Test pipeline failed:", currentBuild.description)
         }
-        cleanup {
-            deleteDir()
-        }
     }
 }

--- a/theforeman.org/pipelines/release/pipelines/plugins.groovy
+++ b/theforeman.org/pipelines/release/pipelines/plugins.groovy
@@ -44,9 +44,4 @@ pipeline {
             }
         }
     }
-    post {
-        cleanup {
-            deleteDir()
-        }
-    }
 }

--- a/theforeman.org/pipelines/release/pipelines/pulpcore.groovy
+++ b/theforeman.org/pipelines/release/pipelines/pulpcore.groovy
@@ -56,9 +56,4 @@ pipeline {
             }
         }
     }
-    post {
-        cleanup {
-            deleteDir()
-        }
-    }
 }


### PR DESCRIPTION
"agent none" can obviously not run a cleanup step, and the stages of
these pipes that do act on local files (very few of them do) have own
cleanup steps already defined