### PR TITLE
Stop pushing Katello RPMs to fedorapeople

### DIFF
--- a/theforeman.org/pipelines/release/pipelines/katello.groovy
+++ b/theforeman.org/pipelines/release/pipelines/katello.groovy
@@ -43,8 +43,10 @@ pipeline {
             agent { label 'admin && sshkey' }
 
             steps {
-                push_rpms_katello(katello_version)
                 script {
+                    if (katello_version in ['3.17', '3.18', '4.0']) {
+                        push_rpms_katello(katello_version)
+                    }
                     foreman_el_releases.each { distro ->
                         push_katello_rpms(katello_version, distro)
                     }


### PR DESCRIPTION
I have updated fedorapeople with an `index.html` file to indicate moving of the repositories and locations for things still hosted there:

https://fedorapeople.org/groups/katello/

Once this has been merged (and any updates to that index.html have been made) I will attempt to clean out the nightly repository on feodrapeople except for the katello-repos RPM.

If there are any updates to that `index.html` suggested, feel free to to put them on this PR and I will go update manually.