### PR TITLE
install pbr before installing jjb

### DIFF
--- a/theforeman.org/pipelines/infra/updateJobs.groovy
+++ b/theforeman.org/pipelines/infra/updateJobs.groovy
@@ -13,6 +13,7 @@ pipeline {
                     ]
                 ])
 
+                virtEnv('jjb-venv', 'pip install pbr')
                 virtEnv('jjb-venv', 'pip install jenkins-job-builder')
             }
         }


### PR DESCRIPTION
for some reason, pip fails to install them if that happens in the same
transaction