### PR TITLE
bump plugins test timeouts

### DIFF
--- a/theforeman.org/pipelines/release/pipelines/plugins-deb.groovy
+++ b/theforeman.org/pipelines/release/pipelines/plugins-deb.groovy
@@ -3,7 +3,7 @@ pipeline {
 
     options {
         timestamps()
-        timeout(time: 2, unit: 'HOURS')
+        timeout(time: 3, unit: 'HOURS')
         disableConcurrentBuilds()
         ansiColor('xterm')
     }

--- a/theforeman.org/pipelines/release/pipelines/plugins-rpm.groovy
+++ b/theforeman.org/pipelines/release/pipelines/plugins-rpm.groovy
@@ -3,7 +3,7 @@ pipeline {
 
     options {
         timestamps()
-        timeout(time: 2, unit: 'HOURS')
+        timeout(time: 3, unit: 'HOURS')
         disableConcurrentBuilds()
         ansiColor('xterm')
     }


### PR DESCRIPTION
those can run a bit longer when ci.centos.org is under load