### PR TITLE
unset expected version

### DIFF
--- a/centos.org/jobs/foreman-pipeline-template.yml
+++ b/centos.org/jobs/foreman-pipeline-template.yml
@@ -6,7 +6,7 @@
     parameters:
       - string:
           name: expected_version
-          default: '3.0.0-develop'
+          default: ''
       - string:
           name: version
           default: '{version}'


### PR DESCRIPTION
we either pass the correct one (in the release jobs) or an empty string
(in the nightly jobs), so there is really no need to keep an artificial
nightly number in here, that is never checked