### PR TITLE
Change to the right directory for executing pbuilder

### DIFF
--- a/theforeman.org/yaml/builders/build_deb_coreproject.yaml
+++ b/theforeman.org/yaml/builders/build_deb_coreproject.yaml
@@ -1,7 +1,9 @@
 - builder:
     name: build_deb_coreproject
     builders:
-      - shell: !include-raw: scripts/debian/configure_pbuilder.sh
-      - shell: !include-raw: scripts/debian/setup_sources_core.sh
-      - shell: !include-raw: scripts/debian/execute_pbuilder.sh
-      - shell: !include-raw: scripts/debian/stage_packages.sh
+      - shell:
+          !include-raw:
+            - scripts/debian/configure_pbuilder.sh
+            - scripts/debian/setup_sources_core.sh
+            - scripts/debian/execute_pbuilder.sh
+            - scripts/debian/stage_packages.sh

--- a/theforeman.org/yaml/builders/build_deb_dependency.yaml
+++ b/theforeman.org/yaml/builders/build_deb_dependency.yaml
@@ -1,7 +1,9 @@
 - builder:
     name: build_deb_dependency
     builders:
-      - shell: !include-raw: scripts/debian/configure_pbuilder.sh
-      - shell: !include-raw: scripts/debian/setup_sources_dependency.sh
-      - shell: !include-raw: scripts/debian/execute_pbuilder.sh
-      - shell: !include-raw: scripts/debian/stage_packages.sh
+      - shell:
+          !include-raw:
+            - scripts/debian/configure_pbuilder.sh
+            - scripts/debian/setup_sources_dependency.sh
+            - scripts/debian/execute_pbuilder.sh
+            - scripts/debian/stage_packages.sh

--- a/theforeman.org/yaml/builders/build_deb_plugin.yaml
+++ b/theforeman.org/yaml/builders/build_deb_plugin.yaml
@@ -1,7 +1,9 @@
 - builder:
     name: build_deb_plugin
     builders:
-      - shell: !include-raw: scripts/debian/configure_pbuilder.sh
-      - shell: !include-raw: scripts/debian/setup_sources_plugin.sh
-      - shell: !include-raw: scripts/debian/execute_pbuilder.sh
-      - shell: !include-raw: scripts/debian/stage_packages.sh
+      - shell:
+          !include-raw:
+            - scripts/debian/configure_pbuilder.sh
+            - scripts/debian/setup_sources_plugin.sh
+            - scripts/debian/execute_pbuilder.sh
+            - scripts/debian/stage_packages.sh

--- a/theforeman.org/yaml/builders/build_deb_proxy_plugin.yaml
+++ b/theforeman.org/yaml/builders/build_deb_proxy_plugin.yaml
@@ -1,7 +1,9 @@
 - builder:
     name: build_deb_proxy_plugin
     builders:
-      - shell: !include-raw: scripts/debian/configure_pbuilder.sh
-      - shell: !include-raw: scripts/debian/setup_sources_plugin.sh
-      - shell: !include-raw: scripts/debian/execute_pbuilder.sh
-      - shell: !include-raw: scripts/debian/stage_packages.sh
+      - shell:
+          !include-raw:
+            - scripts/debian/configure_pbuilder.sh
+            - scripts/debian/setup_sources_plugin.sh
+            - scripts/debian/execute_pbuilder.sh
+            - scripts/debian/stage_packages.sh


### PR DESCRIPTION
Splitting the setup sources from pbduilder execution means that the
implied directory needed to be present in to execute pbuilder was
not correctly set. This needs to be set based on project and where
the built source is located.

Refs: https://github.com/theforeman/jenkins-jobs/commit/da2903bcd68725b68778d3dbaa4e1a66cd32869a