### PR TITLE
Keep stage_packages script as stand-alone shell

### DIFF
--- a/theforeman.org/yaml/builders/build_deb_coreproject.yaml
+++ b/theforeman.org/yaml/builders/build_deb_coreproject.yaml
@@ -6,4 +6,4 @@
             - scripts/debian/configure_pbuilder.sh
             - scripts/debian/setup_sources_core.sh
             - scripts/debian/execute_pbuilder.sh
-            - scripts/debian/stage_packages.sh
+      - shell: !include-raw: scripts/debian/stage_packages.sh

--- a/theforeman.org/yaml/builders/build_deb_dependency.yaml
+++ b/theforeman.org/yaml/builders/build_deb_dependency.yaml
@@ -6,4 +6,4 @@
             - scripts/debian/configure_pbuilder.sh
             - scripts/debian/setup_sources_dependency.sh
             - scripts/debian/execute_pbuilder.sh
-            - scripts/debian/stage_packages.sh
+      - shell: !include-raw: scripts/debian/stage_packages.sh

--- a/theforeman.org/yaml/builders/build_deb_plugin.yaml
+++ b/theforeman.org/yaml/builders/build_deb_plugin.yaml
@@ -6,4 +6,4 @@
             - scripts/debian/configure_pbuilder.sh
             - scripts/debian/setup_sources_plugin.sh
             - scripts/debian/execute_pbuilder.sh
-            - scripts/debian/stage_packages.sh
+      - shell: !include-raw: scripts/debian/stage_packages.sh

--- a/theforeman.org/yaml/builders/build_deb_proxy_plugin.yaml
+++ b/theforeman.org/yaml/builders/build_deb_proxy_plugin.yaml
@@ -6,4 +6,4 @@
             - scripts/debian/configure_pbuilder.sh
             - scripts/debian/setup_sources_plugin.sh
             - scripts/debian/execute_pbuilder.sh
-            - scripts/debian/stage_packages.sh
+      - shell: !include-raw: scripts/debian/stage_packages.sh


### PR DESCRIPTION
The stages script relies on being at the root of the checkout
and this avoids any magic by starting a new shell for this script.

Refs 7ac30489cac327ca0032660de51bfe265d5bcee0