### PR TITLE
Build pbuilder hooks directory via os and project

### DIFF
--- a/theforeman.org/scripts/debian/configure_pbuilder.sh
+++ b/theforeman.org/scripts/debian/configure_pbuilder.sh
@@ -5,23 +5,24 @@ set -xe
 echo "--Apt Hook Setup"
 
 pbuilder_hooksdir=/etc/pbuilder/${os}64/hooks
+addrepo_hook=${pbuilder_hooksdir}/F60-${project}-addforemanrepo
 
 # Cleanup any old hooks
-sudo rm -f ${pbuilder_hooksdir}/F60addforemanrepo
+sudo rm -f $addrepo_hook
 
 if [[ $repoowner != theforeman ]]; then
   # Add a stagingdeb repo to the sources too, if it exists
   if wget -O/dev/null -q http://stagingdeb.theforeman.org/dists/${os}/${repoowner}-${version} ; then
-    echo "echo deb http://stagingdeb.theforeman.org/ ${os} ${repoowner}-${version} >> /etc/apt/sources.list" | sudo tee -a ${pbuilder_hooksdir}/F60addforemanrepo > /dev/null
+    echo "echo deb http://stagingdeb.theforeman.org/ ${os} ${repoowner}-${version} >> /etc/apt/sources.list" | sudo tee -a $addrepo_hook > /dev/null
   fi
   if wget -O/dev/null -q http://stagingdeb.theforeman.org/dists/plugins/${repoowner} ; then
-    echo "echo deb http://stagingdeb.theforeman.org/ plugins ${repoowner} >> /etc/apt/sources.list" | sudo tee -a ${pbuilder_hooksdir}/F60addforemanrepo > /dev/null
+    echo "echo deb http://stagingdeb.theforeman.org/ plugins ${repoowner} >> /etc/apt/sources.list" | sudo tee -a $addrepo_hook > /dev/null
   fi
 fi
 
 # Use tee to get around sudo/redirection problems, with /dev/null to drop the stdout
-echo "echo deb http://deb.theforeman.org/ ${os} ${version} >> /etc/apt/sources.list" | sudo tee -a ${pbuilder_hooksdir}/F60addforemanrepo > /dev/null
-echo "echo deb http://deb.theforeman.org/ plugins ${version} >> /etc/apt/sources.list" | sudo tee -a ${pbuilder_hooksdir}/F60addforemanrepo > /dev/null
+echo "echo deb http://deb.theforeman.org/ ${os} ${version} >> /etc/apt/sources.list" | sudo tee -a $addrepo_hook > /dev/null
+echo "echo deb http://deb.theforeman.org/ plugins ${version} >> /etc/apt/sources.list" | sudo tee -a $addrepo_hook > /dev/null
 
 # Read Foreman package installation logs on failure
 echo "cat /var/log/foreman-install.log || true" | sudo tee ${pbuilder_hooksdir}/C10foremanlog


### PR DESCRIPTION
Without building the hooks directory based on project, multiple
builds on the same box could clear out the hooks directory for that build.
This makes the hooks directory per os per project to create
more scoping.

I suppose we have not really hit this in the past, but when thinking about building out the pipelines and how to ensure a dedicated build setup per project/os combination this seemed like it would be needed.