### PR TITLE
Create an internal folder to hold all JJB jobs

### DIFF
--- a/theforeman.org/yaml/defaults/defaults.yaml
+++ b/theforeman.org/yaml/defaults/defaults.yaml
@@ -13,4 +13,4 @@
       - tfm-build-discarder
     wrappers:
       - timestamps
-
+    folder: internal-folder

--- a/theforeman.org/yaml/jobs/internal_folder.yaml
+++ b/theforeman.org/yaml/jobs/internal_folder.yaml
@@ -1,0 +1,4 @@
+---
+- job:
+    name: internal-folder
+    project-type: folder


### PR DESCRIPTION
From reading, it appeared that to enable Jenkinsfiles without access to all credentials in the system, folders need to be used. By putting credentials and jobs in the same folder, only jobs in that folder can access credentials also in said folder. While we can aim for more granularity over time my idea was the following:

 * create  an internal/JJB folder and put all jobs created via JJB in said folder
 * add all credentials to said folder and have 0 global credentials
 * put multibranch created jobs into a different folder thereby cutting off credential access

That would maintain the current state of our design while enabling to start trying out Jenkinsfiles.