### PR TITLE
Revert "don't double-sudo"

### DIFF
--- a/theforeman.org/scripts/debian/execute_pbuilder.sh
+++ b/theforeman.org/scripts/debian/execute_pbuilder.sh
@@ -5,8 +5,8 @@ set -xe
 echo "--Execute pdebuild"
 
 # Build the package for the OS using pbuilder
-# pbuilder calls sudo internally, so no sudo here
-FOREMAN_VERSION=${version} pdebuild-${os}64
+# needs sudo as pedebuild uses loop and bind mounts
+sudo FOREMAN_VERSION=${version} pdebuild-${os}64
 
 # Cleanup, pdebuild uses root
 sudo chown -R jenkins:jenkins $WORKSPACE


### PR DESCRIPTION
This reverts commit d9d5fe837368bb62cd10ee8d2db139fa9b13111e.

Requires https://github.com/theforeman/foreman-infra/pull/1649

The problem is, the way we build `foreman` today requires root (inside the build environment) and fixing this is a bit delicate depending on which Bundler version we use (it differs between buster, bionic and focal).

While I do have a few ideas, how we could tackle this, none of them are trivial and I would prefer to postpone fixing this particular problem to a later point.