### PR TITLE
Add email list notification

### DIFF
--- a/theforeman.org/yaml/jobs/plugins/foreman_discovery.yaml
+++ b/theforeman.org/yaml/jobs/plugins/foreman_discovery.yaml
@@ -9,4 +9,7 @@
       - 18.0-stable:
           foreman_branch: 3.0-stable
     jobs:
-      - 'test_plugin_{name}_{branch}'
+      - 'test_plugin_{name}_{branch}':
+          publishers:
+            - ircbot_freenode
+            - discourse

--- a/theforeman.org/yaml/publishers/discourse.yaml
+++ b/theforeman.org/yaml/publishers/discourse.yaml
@@ -1,0 +1,5 @@
+- publisher:
+    name: discourse
+    publishers:
+    - email:
+        recipients: ci@community.theforeman.org


### PR DESCRIPTION
A proposal to create a list people could easily subscribe to:

https://community.theforeman.org/t/how-to-subscribe-to-ci-plugin-failures/25328/6

For now, I am just adding plugins develop tests, but once this is approved I will modify all places so emails are sent for everything.