### PR TITLE
Upgrade version bump to 1.21

### DIFF
--- a/theforeman.org/yaml/jobs/test_develop_pr_upgrade.yaml
+++ b/theforeman.org/yaml/jobs/test_develop_pr_upgrade.yaml
@@ -33,7 +33,7 @@
           type: user-defined
           name: old_branch
           values:
-            - 1.17-stable
+            - 1.21-stable
     builders:
       - shell: !include-raw: scripts/test/test_upgrade.sh
     publishers:


### PR DESCRIPTION
We no longer want to support upgrades from older version then 1.21 as the migrations won't be very reliable.
This bumps the tested version to the currently supported one.

This is mostly due to https://github.com/theforeman/foreman/pull/8790