### PR TITLE
force REQUESTS_CA_BUNDLE=/etc/pki/tls/cert.pem

### DIFF
--- a/theforeman.org/pipelines/infra/updateJobs.groovy
+++ b/theforeman.org/pipelines/infra/updateJobs.groovy
@@ -20,7 +20,7 @@ pipeline {
         stage('Update ci.theforeman.org jobs') {
             steps {
                 withCredentials([usernamePassword(credentialsId: 'theforeman-jenkins', usernameVariable: 'USERNAME', passwordVariable: 'PASSWORD')]) {
-                    virtEnv('jjb-venv', "cd ./theforeman.org && jenkins-jobs --conf ./foreman_jenkins.ini --user ${env.USERNAME} --password '${env.PASSWORD}' update --delete-old -r .")
+                    virtEnv('jjb-venv', "cd ./theforeman.org && REQUESTS_CA_BUNDLE=/etc/pki/tls/cert.pem jenkins-jobs --conf ./foreman_jenkins.ini --user ${env.USERNAME} --password '${env.PASSWORD}' update --delete-old -r .")
                 }
             }
         }
@@ -28,7 +28,7 @@ pipeline {
         stage('Update ci.centos.org jobs') {
             steps {
                 withCredentials([string(credentialsId: 'centos-jenkins', variable: 'PASSWORD')]) {
-                    virtEnv('jjb-venv', "cd ./centos.org && jenkins-jobs --conf ./centos_jenkins.ini --user 'foreman' --password '${env.PASSWORD}' update --delete-old -r ./jobs")
+                    virtEnv('jjb-venv', "cd ./centos.org && REQUESTS_CA_BUNDLE=/etc/pki/tls/cert.pem jenkins-jobs --conf ./centos_jenkins.ini --user 'foreman' --password '${env.PASSWORD}' update --delete-old -r ./jobs")
                 }
             }
         }


### PR DESCRIPTION
we install jenkins-jobs via pip, which pulls in certifi, which contains
the old DST X3 root cert, which makes OpenSSL 1.0.x on EL7 freak out and
fail to verify the perfectly valid certs of ci.theforeman.org and
ci.centos.org