### PR TITLE
Stop building on Ubuntu 18.04 Bionic

### DIFF
--- a/theforeman.org/pipelines/lib/packaging.groovy
+++ b/theforeman.org/pipelines/lib/packaging.groovy
@@ -70,7 +70,7 @@ def find_changed_debs(diff_range) {
             type: 'plugin',
             name: project,
             path: "${folder}/${project}",
-            operating_system: 'bionic'
+            operating_system: 'buster'
         ])
     }
 

--- a/theforeman.org/pipelines/vars/foreman/nightly.groovy
+++ b/theforeman.org/pipelines/vars/foreman/nightly.groovy
@@ -11,7 +11,7 @@ def foreman_el_releases = [
     'el7',
     'el8'
 ]
-def foreman_debian_releases = ['buster', 'bionic', 'focal']
+def foreman_debian_releases = ['buster', 'focal']
 
 def pipelines_deb = [
     'install': [

--- a/theforeman.org/yaml/jobs/packaging_build_deb_coreproject.yaml
+++ b/theforeman.org/yaml/jobs/packaging_build_deb_coreproject.yaml
@@ -26,7 +26,7 @@
           values:
           - debian
     execution-strategy:
-      combination-filter: '(onlyos == "all" || onlyos == os) && !((version == "2.4" || version == "2.3" || version == "2.2") && os == "focal")'
+      combination-filter: '(onlyos == "all" || onlyos == os) && !((version == "2.4" || version == "2.3") && os == "focal") && !((version == "3.1" || version == "nightly") && os == "bionic")'
     builders:
       - build_deb_coreproject
     publishers:

--- a/theforeman.org/yaml/jobs/packaging_build_deb_dependency.yaml
+++ b/theforeman.org/yaml/jobs/packaging_build_deb_dependency.yaml
@@ -29,7 +29,7 @@
           values:
           - debian
     execution-strategy:
-      combination-filter: '(onlyos == "all" || onlyos == os) && !((version == "2.4" || version == "2.3") && os == "focal")'
+      combination-filter: '(onlyos == "all" || onlyos == os) && !((version == "2.4" || version == "2.3") && os == "focal") && !((version == "3.1" || version == "nightly") && os == "bionic")'
     builders:
       - build_deb_dependency
     publishers:

--- a/theforeman.org/yaml/jobs/packaging_build_deb_plugin.yaml
+++ b/theforeman.org/yaml/jobs/packaging_build_deb_plugin.yaml
@@ -12,7 +12,7 @@
           type: user-defined
           name: os
           values:
-          - bionic
+          - buster
       - axis:
           type: slave
           name: arch

--- a/theforeman.org/yaml/jobs/packaging_build_deb_proxy_plugin.yaml
+++ b/theforeman.org/yaml/jobs/packaging_build_deb_proxy_plugin.yaml
@@ -16,7 +16,7 @@
           type: user-defined
           name: os
           values:
-          - bionic
+          - buster
       - axis:
           type: slave
           name: arch


### PR DESCRIPTION
This also switches the plugin builds from Bionic to Buster. I wasn't sure if we should switch from Ubuntu to Debian, but Buster is certainly supported on all versions for which we build now and is the oldest.