### PR TITLE
Unpin bundler

### DIFF
--- a/theforeman.org/pipelines/lib/rvm.groovy
+++ b/theforeman.org/pipelines/lib/rvm.groovy
@@ -15,7 +15,7 @@ def gemset(name = null) {
 
 def configureRVM(ruby, name = '') {
     emptyGemset(ruby, name)
-    withRVM(["gem install bundler -v '< 2.0'"], ruby, name)
+    withRVM(["gem install bundler --no-document"], ruby, name)
 }
 
 def emptyGemset(ruby, name = '') {

--- a/theforeman.org/scripts/test/foreman-proxy.sh
+++ b/theforeman.org/scripts/test/foreman-proxy.sh
@@ -15,7 +15,7 @@ rvm use ruby-${ruby}@${gemset} --create
 rvm gemset empty --force
 set -x
 
-gem install bundler -v '< 2.0' --no-document
+gem install bundler --no-document
 
 # Puppet environment
 if [ -e $APP_ROOT/bundler.d/puppet.rb ] ; then

--- a/theforeman.org/scripts/test/test_develop.sh
+++ b/theforeman.org/scripts/test/test_develop.sh
@@ -15,7 +15,7 @@ rvm use ruby-${ruby}@${gemset} --create
 rvm gemset empty --force
 set -x
 
-gem install bundler -v '< 2.0' --no-document
+gem install bundler --no-document
 
 # Retry as rubygems (being external to us) can be intermittent
 bundle install --without=development --jobs=5 --retry=5

--- a/theforeman.org/scripts/test/test_hammer_cli_foreman_discovery.sh
+++ b/theforeman.org/scripts/test/test_hammer_cli_foreman_discovery.sh
@@ -6,7 +6,7 @@
 gemset=$(echo ${JOB_NAME} | cut -d/ -f1)-${EXECUTOR_NUMBER}
 rvm use ruby-${ruby}@${gemset} --create
 rvm gemset empty --force
-gem install bundler -v '< 2.0' --no-document
+gem install bundler --no-document
 
 # Link hammer_cli from github
 echo 'gem "hammer_cli", :github => "theforeman/hammer-cli"' > Gemfile.local

--- a/theforeman.org/scripts/test/test_hammer_cli_foreman_pull_request.sh
+++ b/theforeman.org/scripts/test/test_hammer_cli_foreman_pull_request.sh
@@ -10,7 +10,7 @@ rvm use ruby-${ruby}@${gemset} --create
 rvm gemset empty --force
 set -x
 
-gem install bundler -v '< 2.0' --no-document
+gem install bundler --no-document
 
 # Link hammer_cli from github
 if [ "$ghprbTargetBranch" = "master" ]; then

--- a/theforeman.org/scripts/test/test_hammer_cli_pull_request.sh
+++ b/theforeman.org/scripts/test/test_hammer_cli_pull_request.sh
@@ -10,7 +10,7 @@ rvm use ruby-${ruby}@${gemset} --create
 rvm gemset empty --force
 set -x
 
-gem install bundler -v '< 2.0' --no-document
+gem install bundler --no-document
 
 bundle install --without development --jobs=5 --retry=5
 bundle exec rake ci:setup:minitest test TESTOPTS="-v"

--- a/theforeman.org/scripts/test/test_katello.sh
+++ b/theforeman.org/scripts/test/test_katello.sh
@@ -40,7 +40,7 @@ rvm use ruby-${ruby}@${gemset} --create
 rvm gemset empty --force
 set -x
 
-gem install bundler -v '< 2.0' --no-document
+gem install bundler --no-document
 
 # Now let's introduce the plugin
 echo "gemspec :path => '${PLUGIN_ROOT}', :development_group => :katello_dev" >> bundler.d/Gemfile.local.rb

--- a/theforeman.org/scripts/test/test_plugin.sh
+++ b/theforeman.org/scripts/test/test_plugin.sh
@@ -22,7 +22,7 @@ rvm use ruby-${ruby}@${gemset} --create
 rvm gemset empty --force
 
 set -x
-gem install bundler -v '< 2.0' --no-document
+gem install bundler --no-document
 
 # Retry as rubygems (being external to us) can be intermittent
 bundle install --without=development --jobs=5 --retry=5

--- a/theforeman.org/scripts/test/test_upgrade.sh
+++ b/theforeman.org/scripts/test/test_upgrade.sh
@@ -17,7 +17,7 @@ rvm use ruby-${ruby}@${gemset} --create
 rvm gemset empty --force
 set -x
 
-gem install bundler -v '< 2.0' --no-document
+gem install bundler --no-document
 
 # Retry as rubygems (being external to us) can be intermittent
 bundle install --without development mysql2 --jobs=5 --retry=5

--- a/theforeman.org/yaml/builders/foreman-plugins-pull-request.yaml
+++ b/theforeman.org/yaml/builders/foreman-plugins-pull-request.yaml
@@ -28,7 +28,7 @@
           gemset=$(echo ${{JOB_NAME}} | cut -d/ -f1)-${{EXECUTOR_NUMBER}}
           rvm use ruby-${{ruby}}@${{gemset}} --create
           rvm gemset empty --force
-          gem install bundler -v '< 2.0' --no-document
+          gem install bundler --no-document
 
           bundle install --without development --jobs=5 --retry=5
 

--- a/theforeman.org/yaml/builders/smart-proxy-plugin.yaml
+++ b/theforeman.org/yaml/builders/smart-proxy-plugin.yaml
@@ -13,7 +13,7 @@
           rvm gemset empty --force
           set -x
 
-          gem install bundler -v '< 2.0' --no-document
+          gem install bundler --no-document
 
           bundle install --retry 5 --jobs 5
           bundle exec rake TESTOPTS="--verbose"


### PR DESCRIPTION
We pinned bundler to < 2.0 in 71d247e1933 but forgot to unpin it now
that we don't need to support Ruby 2.2 or older.