### PR TITLE
Drop Ubuntu 18.04 from nightly pipelines

### DIFF
--- a/centos.org/jobs/foreman-pipelines.yml
+++ b/centos.org/jobs/foreman-pipelines.yml
@@ -33,7 +33,6 @@
       - centos8
       - centos8-stream
       - debian10
-      - ubuntu1804
       - ubuntu2004
     version:
       - nightly

--- a/theforeman.org/pipelines/vars/foreman/nightly.groovy
+++ b/theforeman.org/pipelines/vars/foreman/nightly.groovy
@@ -16,12 +16,10 @@ def foreman_debian_releases = ['buster', 'focal']
 def pipelines_deb = [
     'install': [
         'debian10',
-        'ubuntu1804',
         'ubuntu2004'
     ],
     'upgrade': [
         'debian10',
-        'ubuntu1804',
         'ubuntu2004'
     ]
 ]


### PR DESCRIPTION
Previously the builds were dropped. This also stops running pipelines.

Fixes: 46f365a084210878e3e8d3edd4a548919a376152