### PR TITLE
always take the last lastBuiltRevision

### DIFF
--- a/theforeman.org/pipelines/lib/packaging.groovy
+++ b/theforeman.org/pipelines/lib/packaging.groovy
@@ -241,7 +241,7 @@ def setup_sources_core(project, os, version, repoowner, pull_request = false) {
               mv archive/pkg/*bz2 ${project}_${package_version}.orig.tar.bz2
             """
 
-            last_commit = sh(returnStdout: true, script: "curl \"${job_url}/api/json\" | jq -r '.actions[].lastBuiltRevision.SHA1 | values'").trim()
+            last_commit = sh(returnStdout: true, script: "curl --silent \"${job_url}/api/json\" | jq -r '.actions | map(select(has(\"lastBuiltRevision\"))) | .[-1].lastBuiltRevision.SHA1'").trim()
         } else {
             sh """
               # Download sources


### PR DESCRIPTION
sometimes, a source-release job is triggered by multiple merges, which
results in multiple BuildData objects being present in the JSON output

the old jq query printed *all* SHA1 of these, resulting in bad Debian
changelogs being generated

lets take only the last entry and print its SHA1