### PR TITLE
Fix groovy detecting dynamic map key and echo repos map that is gener…

### DIFF
--- a/theforeman.org/pipelines/lib/packaging.groovy
+++ b/theforeman.org/pipelines/lib/packaging.groovy
@@ -155,12 +155,13 @@ def build_deb_package_steps(packages_to_build, version, repoowner = 'theforeman'
             echo "scratch build: uploading to stagingdeb/${suite}/${component}"
         }
 
-        if (!repos.containsKey("${suite}-${component}")) {
+        if (!repos["${suite}-${component}"]) {
             repos["${suite}-${component}"] = [suite: suite, component: component, deb_paths: [], type: release_type]
         }
         repos["${suite}-${component}"].deb_paths.add("${deb_path}/*deb")
     }
 
+    echo "Repos to rsync: ${repos}"
     repos.each { key, value ->
         if (value.type == 'stage') {
             steps.rsync_packages[key] = {


### PR DESCRIPTION
…ated for debugging

@evgeni I tested this in a re-run (https://ci.theforeman.org/blue/organizations/jenkins/foreman-packaging-deb-nightly-release/detail/foreman-packaging-deb-nightly-release/43/pipeline/) and saw the following which looks much better:

```
[2021-11-09T20:49:55.721Z] + export RSYNC_RSH=ssh -i /home/jenkins/workspace/deb_key/rsync_freight_key
[2021-11-09T20:49:55.722Z] + /usr/bin/rsync -avPx plugins/build-ruby-foreman-datacenter/ruby-foreman-datacenter_2.3.0-2_all.deb plugins/build-ruby-foreman-expire-hosts/ruby-foreman-expire-hosts_7.0.0-2_all.deb plugins/build-ruby-foreman-fog-proxmox/ruby-foreman-fog-proxmox_0.14.0-2_all.deb plugins/build-ruby-foreman-rescue/ruby-foreman-rescue_2.0.1-2_all.deb plugins/build-ruby-foreman-setup/ruby-foreman-setup_6.0.0-2_all.deb plugins/build-ruby-foreman-webhooks/ruby-foreman-webhooks_3.0.0-2_all.deb plugins/build-ruby-puppetdb-foreman/ruby-puppetdb-foreman_5.0.0-2_all.deb freight@web01.osuosl.theforeman.org:rsync_cache/plugins/nightly/

[2021-11-09T20:49:58.719Z] sending incremental file list

[2021-11-09T20:49:58.719Z] ruby-foreman-datacenter_2.3.0-2_all.deb

[2021-11-09T20:49:58.719Z] 
         32,768   3%    0.00kB/s    0:00:00  
        886,004 100%  271.24MB/s    0:00:00 (xfr#1, to-chk=6/7)

[2021-11-09T20:49:58.719Z] ruby-foreman-expire-hosts_7.0.0-2_all.deb

[2021-11-09T20:49:58.719Z] 
         32,768  20%   10.42MB/s    0:00:00  
        160,428 100%   30.60MB/s    0:00:00 (xfr#2, to-chk=5/7)

[2021-11-09T20:49:58.719Z] ruby-foreman-fog-proxmox_0.14.0-2_all.deb

[2021-11-09T20:49:58.719Z] 
         32,768   7%    6.25MB/s    0:00:00  
        454,956 100%   39.44MB/s    0:00:00 (xfr#3, to-chk=4/7)

[2021-11-09T20:49:58.719Z] ruby-foreman-rescue_2.0.1-2_all.deb

[2021-11-09T20:49:58.719Z] 
         24,568 100%    2.13MB/s    0:00:00  
         24,568 100%    2.13MB/s    0:00:00 (xfr#4, to-chk=3/7)

[2021-11-09T20:49:58.719Z] ruby-foreman-setup_6.0.0-2_all.deb

[2021-11-09T20:49:58.719Z] 
         32,768  66%    2.60MB/s    0:00:00  
         49,596 100%    3.64MB/s    0:00:00 (xfr#5, to-chk=2/7)

[2021-11-09T20:49:58.719Z] ruby-foreman-webhooks_3.0.0-2_all.deb

[2021-11-09T20:50:00.096Z] 
         32,768   1%    2.40MB/s    0:00:00  
        950,272  50%  924.30kB/s    0:00:01  
      1,888,356 100%    1.53MB/s    0:00:01 (xfr#6, to-chk=1/7)

[2021-11-09T20:50:00.096Z] ruby-puppetdb-foreman_5.0.0-2_all.deb

[2021-11-09T20:50:00.096Z] 
         32,768  20%  183.91kB/s    0:00:00  
        158,672 100%  885.45kB/s    0:00:00 (xfr#7, to-chk=0/7)

[2021-11-09T20:50:00.817Z] # [freight] apt/plugins/nightly already has /home/freight/rsync_cache/plugins/nightly/ruby-foreman-datacenter_2.3.0-2_all.deb

[2021-11-09T20:50:00.817Z] # [freight] apt/plugins/nightly already has /home/freight/rsync_cache/plugins/nightly/ruby-foreman-expire-hosts_7.0.0-2_all.deb

[2021-11-09T20:50:00.817Z] # [freight] apt/plugins/nightly already has /home/freight/rsync_cache/plugins/nightly/ruby-foreman-fog-proxmox_0.14.0-2_all.deb

[2021-11-09T20:50:00.818Z] # [freight] apt/plugins/nightly already has /home/freight/rsync_cache/plugins/nightly/ruby-foreman-rescue_2.0.1-2_all.deb

[2021-11-09T20:50:00.818Z] # [freight] apt/plugins/nightly already has /home/freight/rsync_cache/plugins/nightly/ruby-foreman-setup_6.0.0-2_all.deb

[2021-11-09T20:50:00.818Z] # [freight] apt/plugins/nightly already has /home/freight/rsync_cache/plugins/nightly/ruby-foreman-webhooks_3.0.0-2_all.deb

[2021-11-09T20:50:00.818Z] # [freight] apt/plugins/nightly already has /home/freight/rsync_cache/plugins/nightly/ruby-puppetdb-foreman_5.0.0-2_all.deb

[2021-11-09T20:50:56.017Z] 

[2021-11-09T20:50:56.017Z] sent 3,624,075 bytes  received 149 bytes  658,949.82 bytes/sec

[2021-11-09T20:50:56.017Z] total size is 3,622,580  speedup is 1.00
```