### PR TITLE
search for cico plugin in both Python 2.7 and Python 3.6 installs

### DIFF
--- a/centos.org/ansible/ansible.cfg
+++ b/centos.org/ansible/ansible.cfg
@@ -1,5 +1,5 @@
 [defaults]
 # Attempt to load cico Ansible module whether it's installed system-wide or from a virtual environment
-library = /usr/lib/python2.7/site-packages/cicoclient/ansible:$VIRTUAL_ENV/lib/python2.7/site-packages/cicoclient/ansible
+library = /usr/lib/python2.7/site-packages/cicoclient/ansible:$VIRTUAL_ENV/lib/python2.7/site-packages/cicoclient/ansible:/usr/lib/python3.6/site-packages/cicoclient/ansible:$VIRTUAL_ENV/lib/python3.6/site-packages/cicoclient/ansible
 host_key_checking = False
 retry_files_enabled = False


### PR DESCRIPTION
new el8 cico pods use python 3.6