### PR TITLE
nightly: test bullseye

### DIFF
--- a/centos.org/jobs/foreman-pipelines.yml
+++ b/centos.org/jobs/foreman-pipelines.yml
@@ -53,6 +53,7 @@
       - centos8
       - centos8-stream
       - debian10
+      - debian11
       - ubuntu2004
     version:
       - nightly

--- a/theforeman.org/pipelines/vars/foreman/nightly.groovy
+++ b/theforeman.org/pipelines/vars/foreman/nightly.groovy
@@ -16,6 +16,7 @@ def foreman_debian_releases = ['buster', 'focal']
 def pipelines_deb = [
     'install': [
         'debian10',
+        'debian11',
         'ubuntu2004'
     ],
     'upgrade': [


### PR DESCRIPTION
this will currently fail, as there are no bullseye packages for `puppetserver` and our pipelines don't apply silly hacks (usually)