### PR TITLE
Set JEST_TIMEOUT for katello react-ui

### DIFF
--- a/theforeman.org/pipelines/release/source/katello.groovy
+++ b/theforeman.org/pipelines/release/source/katello.groovy
@@ -77,7 +77,7 @@ pipeline {
                     }
                     steps {
                         sh "npm install --no-audit"
-                        sh 'npm test'
+                        sh 'JEST_TIMEOUT=300000 npm test'
                     }
                 }
                 stage('angular-ui') {


### PR DESCRIPTION
This moves the 300 second timeout to CI only and out of dev so that we can keep a better eye on long-running tests