### PR TITLE
Clean the gem cleanup

### DIFF
--- a/theforeman.org/scripts/gemset_cleanup.sh
+++ b/theforeman.org/scripts/gemset_cleanup.sh
@@ -17,8 +17,8 @@ rvm use ruby-${ruby}@${gemset}
 set -x
 
 # Env var works around Rails issue #28001 if DB migrations fail
-bundle exec rake db:drop DISABLE_DATABASE_ENVIRONMENT_CHECK=true || true
-bundle exec rake db:drop RAILS_ENV=production DISABLE_DATABASE_ENVIRONMENT_CHECK=true || true
+bundle exec rake db:drop DISABLE_DATABASE_ENVIRONMENT_CHECK=true 2>/dev/null || true
+bundle exec rake db:drop RAILS_ENV=production DISABLE_DATABASE_ENVIRONMENT_CHECK=true 2>/dev/null || true
 
 echo "Delete gemset"
 set +x


### PR DESCRIPTION
Every plugin run ends with a big stacktrace because production database does not exist, thus it cannot be dropped. Also the output is extremely noisy and undreadable - several pages of irrelevant messages:

```
+ bundle exec rake db:drop DISABLE_DATABASE_ENVIRONMENT_CHECK=true
Your RubyGems version (3.0.6)) has a bug that prevents `required_ruby_version` from working for Bundler. Any scripts that use `gem install bundler` will break as soon as Bundler drops support for your Ruby version. Please upgrade RubyGems to avoid future breakage and silence this warning by running `gem update --system 3.2.3`
2022-01-12T16:07:44 [I|app|] Rails cache backend: File
2022-01-12T16:07:48 [W|app|] DEPRECATION WARNING: You are using a deprecated behavior, it will be removed in version 3.3, initial value of setting 'instance_id' should be created in a migration (called from block in load_definitions at /home/jenkins/workspace/foreman_discovery-pull-request/database/postgresql/label/fast/ruby/2.5/foreman/app/services/setting_registry.rb:138)
2022-01-12T16:07:48 [D|app|] Updated cached value for setting=discovery_location
2022-01-12T16:07:48 [D|app|] Updated cached value for setting=discovery_organization
2022-01-12T16:07:48 [D|app|] Updated cached value for setting=discovery_fact
2022-01-12T16:07:48 [D|app|] Updated cached value for setting=discovery_auto_bond
2022-01-12T16:07:48 [D|app|] Updated cached value for setting=discovery_clean_facts
2022-01-12T16:07:48 [D|app|] Updated cached value for setting=discovery_hostname
2022-01-12T16:07:48 [D|app|] Updated cached value for setting=discovery_auto
2022-01-12T16:07:48 [D|app|] Updated cached value for setting=discovery_reboot
2022-01-12T16:07:48 [D|app|] Updated cached value for setting=discovery_prefix
2022-01-12T16:07:48 [D|app|] Updated cached value for setting=discovery_fact_column
2022-01-12T16:07:48 [D|app|] Updated cached value for setting=discovery_facts_highlights
2022-01-12T16:07:48 [D|app|] Updated cached value for setting=discovery_facts_storage
2022-01-12T16:07:48 [D|app|] Updated cached value for setting=discovery_facts_software
2022-01-12T16:07:48 [D|app|] Updated cached value for setting=discovery_facts_hardware
2022-01-12T16:07:48 [D|app|] Updated cached value for setting=discovery_facts_network
2022-01-12T16:07:48 [D|app|] Updated cached value for setting=discovery_facts_ipmi
2022-01-12T16:07:48 [D|app|] Updated cached value for setting=discovery_lock
2022-01-12T16:07:48 [D|app|] Updated cached value for setting=discovery_pxelinux_lock_template
2022-01-12T16:07:48 [D|app|] Updated cached value for setting=discovery_pxegrub_lock_template
2022-01-12T16:07:48 [D|app|] Updated cached value for setting=discovery_pxegrub2_lock_template
2022-01-12T16:07:48 [D|app|] Updated cached value for setting=discovery_always_rebuild_dns
2022-01-12T16:07:48 [D|app|] Updated cached value for setting=discovery_error_on_existing
2022-01-12T16:07:48 [D|app|] Updated cached value for setting=discovery_naming
2022-01-12T16:07:48 [D|app|] Updated cached value for setting=discovery_prefer_ipv6
2022-01-12T16:07:48 [D|app|] Slow initializers:
2022-01-12T16:07:48 [D|app|]    1862.68  ./config/initializers/foreman.rb
The Apipie cache is turned off. Enable it and run apipie:cache rake task to speed up API calls.
2022-01-12T16:07:48 [W|app|] DEPRECATION WARNING: Initialization autoloaded the constants SettingRegistry, HostMix, HasManyCommon, StripWhitespace, Parameterizable, AuditAssociations, ApplicationRecord, EncryptValue, PermissionName, UrlSchemaValidator, RegexpValidator, ArrayTypeValidator, ArrayHostnamesIpsValidator, EmailValidator, Setting, Setting::Discovered, Authorizable, ScopedSearchExtensions, Role, TemplateKind, Exportable, ValidateOsFamily, DirtyAssociations, TaxonomyCollisionFinder, EnsureNotUsedBy, PxeLoaderSupport, ParameterValidators, ParameterSearch, NoWhitespaceValidator, Foreman::Fips, PasswordCrypt, Operatingsystem, Taxonomix, TemplateTax, Ptable, Template, ProvisioningTemplate, Foreman::Model, Encryptable, ComputeResource, KeyPairComputeResource, KeyPairCapabilities, Foreman::Model::EC2, FogExtensions::AWS, FogExtensions::AWS::Flavor, FogExtensions::AWS::Tag, FogExtensions::AWS::Server, Foreman::Model::GCE, FogExtensions::Google, FogExtensions::Google::MachineType, FogExtensions::Google::Server, ComputeResourceConsoleCommon, Foreman::Model::Libvirt, FogExtensions::Libvirt, FogExtensions::Libvirt::Server, Foreman::Model::Ovirt, FogExtensions::Ovirt, FogExtensions::Ovirt::Server, FogExtensions::Ovirt::Template, FogExtensions::Ovirt::Volume, Foreman::Model::Openstack, FogExtensions::Openstack, FogExtensions::Openstack::Core, FogExtensions::Openstack::Server, FogExtensions::Openstack::Flavor, ComputeResourceCaching, Foreman::Model::Vmware, FogExtensions::Vsphere::Server, FogExtensions::Vsphere::Folder, FogExtensions, Net::Validations, SettingSelectCollection, HiddenValue, SettingPresenter, Foreman::Deprecation, MediumProviders, MediumProviders::Provider, MediumProviders::Default, Foreman::TelemetryHelper, Foreman::STI, BelongsToProxies, Foreman::Observable, Foreman::ObservableModel, ProxyFeaturesValidator, Subnet, Host, DestroyFlag, InterfaceCloning, Hostext, Hostext::Ownership, Facets, Facets::ModelExtensionsBase, Facets::BaseHostExtensions, PxeLoaderSuggestion, Host::Base, Hostext::PowerInterface, Hostext::Search, ConfigurationStatusScopedSearch, SmartProxyHostExtensions, Report, ConfigReport, HostStatus::ConfigurationStatus, HostStatus::BuildStatus, HostStatus::Status, HostStatus, HostStatus::Global, Hostext::SmartProxy, Hostext::Token, Hostext::OperatingSystem, Hostext::Puppetca, SelectiveClone, HostInfoExtensions, HostInfo, HostInfoProviders, HostInfo::Provider, HostInfoProviders::StaticInfo, HostInfoProviders::HostParamsInfo, HostParams, Facets::ManagedHostExtensions, ForemanRegister, ForemanRegister::HostExtensions, Hostext::UINotifications, PxeLoaderValidator, HostCommon, ProxyReferenceRegistry, SmartProxyReference, ProxyAPI, Orchestration::Task, Orchestration::Queue, Orchestration::ProgressReport, Orchestration, Orchestration::Common, Orchestration::Compute, Orchestration::Puppetca, Orchestration::SSHProvision, Orchestration::Realm, Foreman::ForemanUrlRenderer, HostTemplateHelpers, Host::Managed, NestedAncestryCommon, NestedAncestryCommon::Search, Facets::HostgroupExtensions, SubnetsConsistencyValidator, and Hostgroup.
 | 
 | Being able to do this is deprecated. Autoloading during initialization is going
 | to be an error condition in future versions of Rails.
 | 
 | Reloading does not reboot the application, and therefore code executed during
 | initialization does not run again. So, if you reload SettingRegistry, for example,
 | the expected changes won't be reflected in that stale Class object.
 | 
 | `config.autoloader` is set to `classic`. These autoloaded constants would have been unloaded if `config.autoloader` had been set to `:zeitwerk`.
 | 
 | Please, check the "Autoloading and Reloading Constants" guide for solutions.
 |  (called from block in run at /home/jenkins/workspace/foreman_discovery-pull-request/database/postgresql/label/fast/ruby/2.5/foreman/config/initializers/0_print_time_spent.rb:45)
2022-01-12T16:07:48 [W|app|] Creating scope :completer_scope. Overwriting existing method Location.completer_scope.
2022-01-12T16:07:48 [W|app|] Creating scope :completer_scope. Overwriting existing method Organization.completer_scope.
2022-01-12T16:07:49 [W|app|] DEPRECATION WARNING: Controller-level `force_ssl` is deprecated and will be removed from Rails 6.1. Please enable `config.force_ssl` in your environment configuration to enable the ActionDispatch::SSL middleware to more fully enforce that your application communicate over HTTPS. If needed, you can use `config.ssl_options` to exempt matching endpoints from being redirected to HTTPS. (called from block in <module:RequireSsl> at /home/jenkins/workspace/foreman_discovery-pull-request/database/postgresql/label/fast/ruby/2.5/foreman/app/controllers/concerns/foreman/controller/require_ssl.rb:7)
2022-01-12T16:07:49 [W|app|] DEPRECATION WARNING: Controller-level `force_ssl` is deprecated and will be removed from Rails 6.1. Please enable `config.force_ssl` in your environment configuration to enable the ActionDispatch::SSL middleware to more fully enforce that your application communicate over HTTPS. If needed, you can use `config.ssl_options` to exempt matching endpoints from being redirected to HTTPS. (called from block in <module:RequireSsl> at /home/jenkins/workspace/foreman_discovery-pull-request/database/postgresql/label/fast/ruby/2.5/foreman/app/controllers/concerns/foreman/controller/require_ssl.rb:7)
Dropped database 'test-foreman_discovery-pull-request-0-dev'
Dropped database 'test-foreman_discovery-pull-request-0'
+ bundle exec rake db:drop RAILS_ENV=production DISABLE_DATABASE_ENVIRONMENT_CHECK=true
Your RubyGems version (3.0.6)) has a bug that prevents `required_ruby_version` from working for Bundler. Any scripts that use `gem install bundler` will break as soon as Bundler drops support for your Ruby version. Please upgrade RubyGems to avoid future breakage and silence this warning by running `gem update --system 3.2.3`
rake aborted!
ActiveRecord::AdapterNotSpecified: The `production` database is not configured for the `production` environment.

Available databases configurations are:

development
test
/usr/local/rvm/gems/ruby-2.5.1@foreman_discovery-pull-request-0/gems/activerecord-6.0.3.7/lib/active_record/connection_adapters/connection_specification.rb:250:in `resolve_symbol_connection'
/usr/local/rvm/gems/ruby-2.5.1@foreman_discovery-pull-request-0/gems/activerecord-6.0.3.7/lib/active_record/connection_adapters/connection_specification.rb:218:in `resolve_connection'
/usr/local/rvm/gems/ruby-2.5.1@foreman_discovery-pull-request-0/gems/activerecord-6.0.3.7/lib/active_record/connection_adapters/connection_specification.rb:139:in `resolve'
/usr/local/rvm/gems/ruby-2.5.1@foreman_discovery-pull-request-0/gems/activerecord-6.0.3.7/lib/active_record/connection_handling.rb:170:in `resolve_config_for_connection'
/usr/local/rvm/gems/ruby-2.5.1@foreman_discovery-pull-request-0/gems/activerecord-6.0.3.7/lib/active_record/connection_handling.rb:50:in `establish_connection'
/usr/local/rvm/gems/ruby-2.5.1@foreman_discovery-pull-request-0/gems/activerecord-6.0.3.7/lib/active_record/railtie.rb:201:in `block (2 levels) in <class:Railtie>'
/usr/local/rvm/gems/ruby-2.5.1@foreman_discovery-pull-request-0/gems/activesupport-6.0.3.7/lib/active_support/lazy_load_hooks.rb:71:in `class_eval'
/usr/local/rvm/gems/ruby-2.5.1@foreman_discovery-pull-request-0/gems/activesupport-6.0.3.7/lib/active_support/lazy_load_hooks.rb:71:in `block in execute_hook'
/usr/local/rvm/gems/ruby-2.5.1@foreman_discovery-pull-request-0/gems/activesupport-6.0.3.7/lib/active_support/lazy_load_hooks.rb:61:in `with_execution_control'
/usr/local/rvm/gems/ruby-2.5.1@foreman_discovery-pull-request-0/gems/activesupport-6.0.3.7/lib/active_support/lazy_load_hooks.rb:66:in `execute_hook'
/usr/local/rvm/gems/ruby-2.5.1@foreman_discovery-pull-request-0/gems/activesupport-6.0.3.7/lib/active_support/lazy_load_hooks.rb:43:in `block in on_load'
/usr/local/rvm/gems/ruby-2.5.1@foreman_discovery-pull-request-0/gems/activesupport-6.0.3.7/lib/active_support/lazy_load_hooks.rb:42:in `each'
/usr/local/rvm/gems/ruby-2.5.1@foreman_discovery-pull-request-0/gems/activesupport-6.0.3.7/lib/active_support/lazy_load_hooks.rb:42:in `on_load'
/usr/local/rvm/gems/ruby-2.5.1@foreman_discovery-pull-request-0/gems/activerecord-6.0.3.7/lib/active_record/railtie.rb:198:in `block in <class:Railtie>'
/usr/local/rvm/gems/ruby-2.5.1@foreman_discovery-pull-request-0/gems/railties-6.0.3.7/lib/rails/initializable.rb:32:in `instance_exec'
/usr/local/rvm/gems/ruby-2.5.1@foreman_discovery-pull-request-0/gems/railties-6.0.3.7/lib/rails/initializable.rb:32:in `run'
/usr/local/rvm/gems/ruby-2.5.1@foreman_discovery-pull-request-0/gems/railties-6.0.3.7/lib/rails/initializable.rb:61:in `block in run_initializers'
/usr/local/rvm/gems/ruby-2.5.1@foreman_discovery-pull-request-0/gems/railties-6.0.3.7/lib/rails/initializable.rb:60:in `run_initializers'
/usr/local/rvm/gems/ruby-2.5.1@foreman_discovery-pull-request-0/gems/railties-6.0.3.7/lib/rails/application.rb:363:in `initialize!'
/usr/local/rvm/gems/ruby-2.5.1@foreman_discovery-pull-request-0/gems/railties-6.0.3.7/lib/rails/railtie.rb:190:in `public_send'
/usr/local/rvm/gems/ruby-2.5.1@foreman_discovery-pull-request-0/gems/railties-6.0.3.7/lib/rails/railtie.rb:190:in `method_missing'
/home/jenkins/workspace/foreman_discovery-pull-request/database/postgresql/label/fast/ruby/2.5/foreman/config/environment.rb:5:in `<top (required)>'
/usr/local/rvm/gems/ruby-2.5.1@foreman_discovery-pull-request-0/gems/activesupport-6.0.3.7/lib/active_support/dependencies.rb:324:in `require'
/usr/local/rvm/gems/ruby-2.5.1@foreman_discovery-pull-request-0/gems/activesupport-6.0.3.7/lib/active_support/dependencies.rb:324:in `block in require'
/usr/local/rvm/gems/ruby-2.5.1@foreman_discovery-pull-request-0/gems/activesupport-6.0.3.7/lib/active_support/dependencies.rb:291:in `load_dependency'
/usr/local/rvm/gems/ruby-2.5.1@foreman_discovery-pull-request-0/gems/activesupport-6.0.3.7/lib/active_support/dependencies.rb:324:in `require'
/usr/local/rvm/gems/ruby-2.5.1@foreman_discovery-pull-request-0/gems/railties-6.0.3.7/lib/rails/application.rb:339:in `require_environment!'
/usr/local/rvm/gems/ruby-2.5.1@foreman_discovery-pull-request-0/gems/railties-6.0.3.7/lib/rails/application.rb:523:in `block in run_tasks_blocks'
/usr/local/rvm/gems/ruby-2.5.1@foreman_discovery-pull-request-0/gems/rake-13.0.6/exe/rake:27:in `<top (required)>'
/usr/local/rvm/gems/ruby-2.5.1@foreman_discovery-pull-request-0/bin/ruby_executable_hooks:24:in `eval'
/usr/local/rvm/gems/ruby-2.5.1@foreman_discovery-pull-request-0/bin/ruby_executable_hooks:24:in `<main>'
Tasks: TOP => db:drop => db:load_config => environment
(See full trace by running task with --trace)
+ true
+ echo 'Delete gemset'
Delete gemset
+ set +x
Removing gemset foreman_discovery-pull-request-0......
+ exit 0
POST BUILD TASK : SUCCESS
```

This is very confusing for new contributors, also experienced users need to scroll up and try to find the real stacktrace. This is bugging me.

I propose to simply silent the output - output code will still be readable via `true` if needed. I think the harm it does is much bigger the risk that it could actually silently fail in the future.

Also, I think we do not actually need to drop production db at all, we used to have it for building assets, however, we have the NullDB driver now:

```
theforeman.org/scripts/gemset_cleanup.sh
21:bundle exec rake db:drop RAILS_ENV=production DISABLE_DATABASE_ENVIRONMENT_CHECK=true || true

theforeman.org/scripts/test/test_develop.sh
59:  bundle exec rake assets:precompile RAILS_ENV=production DATABASE_URL=nulldb://nohost
60:  bundle exec rake webpack:compile RAILS_ENV=production DATABASE_URL=nulldb://nohost

theforeman.org/pipelines/test/testKatello.groovy
102:                                withRVM(['bundle exec rake plugin:assets:precompile[katello] RAILS_ENV=production DATABASE_URL=nulldb://nohost --trace'], ruby)

theforeman.org/pipelines/release/source/katello.groovy
100:                            withRVM(["bundle exec rake plugin:assets:precompile[${project_name}] RAILS_ENV=production --trace"], ruby)

theforeman.org/pipelines/release/source/foreman.groovy
130:                                withRVM(['bundle exec rake assets:precompile RAILS_ENV=production DATABASE_URL=nulldb://nohost'], env.RUBY_VER, env.GEMSET)

theforeman.org/pipelines/lib/foreman.groovy
19:    withRVM(['RAILS_ENV=production bundle exec rake db:create --trace'], ruby, name)
26:        withRVM(['bundle exec rake db:drop RAILS_ENV=production DISABLE_DATABASE_ENVIRONMENT_CHECK=true || true'], ruby, name)
```

Alternatively, we could simply delete the production drop which is the main offender.