### PR TITLE
Add release view templates

### DIFF
--- a/theforeman.org/yaml/views/release.yml
+++ b/theforeman.org/yaml/views/release.yml
@@ -1,0 +1,22 @@
+- view-template:
+    name: 'Foreman {major}.{minor}'
+    description: 'Foreman {major}.{minor} jobs'
+    view-type: list
+    regex: '.*{major}[_\.]{minor}.*'
+
+- project:
+    name: 'foreman-releases'
+    views:
+        - 'Foreman {major}.{minor}'
+    major:
+        - '3'
+    minor:
+        - '0'
+        - '1'
+        - '2'
+
+- view:
+    name: 'Foreman Nightly'
+    description: 'Foreman nightly jobs'
+    view-type: list
+    regex: '.+-((nightly|plugins)-(rpm|deb)-pipeline|(develop|master|source|package)-(test|release))'


### PR DESCRIPTION
This adds templated views for releases which makes it easier to have the correct version tabs for a quick overview.

Currently untested. I've followed https://docs.openstack.org/infra/jenkins-job-builder/definition.html#views but I don't know if this will start to purge unmanaged views.

Fixes #169