### PR TITLE
Remove invalid timed run on luna pipeline

### DIFF
--- a/theforeman.org/yaml/jobs/pipeline/luna-nightly-rpm-pipeline.yaml
+++ b/theforeman.org/yaml/jobs/pipeline/luna-nightly-rpm-pipeline.yaml
@@ -3,7 +3,6 @@
     project-type: pipeline
     sandbox: true
     triggers:
-      - timed: 'H 23 * * Wed'
       - reverse:
           jobs:
             - katello-nightly-rpm-pipeline


### PR DESCRIPTION
This fixes an error that shows up in Manage Old Data:

    ConversionException: Failed calling method ---- Debugging information ---- message : Failed calling method cause-exception : java.io.InvalidObjectException cause-message : Invalid input: "H 23 * * Wed": line 1:10: unexpected char: 'W' method : hudson.triggers.TimerTrigger.readResolve() class : hudson.triggers.TimerTrigger required-type : hudson.triggers.TimerTrigger converter-type : hudson.util.RobustReflectionConverter path : /flow-definition/properties/org.jenkinsci.plugins.workflow.job.properties.PipelineTriggersJobProperty/triggers/hudson.triggers.TimerTrigger line number : 287 -------------------------------