### PR TITLE
Clean up plugin testing

### DIFF
--- a/theforeman.org/yaml/jobs/foreman-plugins-pull-request.yaml
+++ b/theforeman.org/yaml/jobs/foreman-plugins-pull-request.yaml
@@ -52,8 +52,6 @@
 - project:
     name: foreman-plugin-pull-request
     plugin:
-      - foreman_ansible:
-          repo: 'https://github.com/theforeman/foreman_ansible'
       - foreman_bootdisk:
           repo: 'https://github.com/theforeman/foreman_bootdisk'
       - foreman_default_hostgroup:
@@ -66,8 +64,6 @@
           repo: 'https://github.com/theforeman/foreman_host_extra_validator'
       - foreman_openscap:
           repo: 'https://github.com/theforeman/foreman_openscap'
-      - foreman_salt:
-          repo: 'https://github.com/theforeman/foreman_salt'
       - foreman_setup:
           repo: 'https://github.com/theforeman/foreman_setup'
       - foreman_templates:

--- a/theforeman.org/yaml/jobs/foreman-plugins-pull-request.yaml
+++ b/theforeman.org/yaml/jobs/foreman-plugins-pull-request.yaml
@@ -58,8 +58,6 @@
           repo: 'https://github.com/theforeman/foreman_bootdisk'
       - foreman_default_hostgroup:
           repo: 'https://github.com/theforeman/foreman_default_hostgroup'
-      - foreman_digitalocean:
-          repo: 'https://github.com/theforeman/foreman-digitalocean'
       - foreman_discovery:
           repo: 'https://github.com/theforeman/foreman_discovery'
       - foreman_docker:

--- a/theforeman.org/yaml/jobs/plugins/foreman-tasks.yaml
+++ b/theforeman.org/yaml/jobs/plugins/foreman-tasks.yaml
@@ -1,8 +1,0 @@
-- project:
-    name: foreman-tasks
-    defaults: plugin
-    branch:
-      - master:
-          foreman_branch: develop
-    jobs:
-      - 'test_plugin_{name}_{branch}'

--- a/theforeman.org/yaml/jobs/plugins/foreman_ansible.yaml
+++ b/theforeman.org/yaml/jobs/plugins/foreman_ansible.yaml
@@ -1,6 +1,0 @@
-- project:
-    name: foreman_ansible
-    repo: foreman_ansible
-    defaults: plugin
-    jobs:
-      - 'test_plugin_{name}_{branch}'

--- a/theforeman.org/yaml/jobs/plugins/foreman_digitalocean.yaml
+++ b/theforeman.org/yaml/jobs/plugins/foreman_digitalocean.yaml
@@ -1,6 +1,0 @@
-- project:
-    name: foreman_digitalocean
-    repo: foreman-digitalocean
-    defaults: plugin
-    jobs:
-      - 'test_plugin_{name}_{branch}'

--- a/theforeman.org/yaml/jobs/plugins/foreman_remote_execution.yaml
+++ b/theforeman.org/yaml/jobs/plugins/foreman_remote_execution.yaml
@@ -1,8 +1,0 @@
-- project:
-    name: foreman_remote_execution
-    defaults: plugin
-    branch:
-      - master:
-          foreman_branch: develop
-    jobs:
-      - 'test_plugin_{name}_{branch}'

--- a/theforeman.org/yaml/jobs/plugins/foreman_salt.yaml
+++ b/theforeman.org/yaml/jobs/plugins/foreman_salt.yaml
@@ -1,5 +1,0 @@
-- project:
-    name: foreman_salt
-    defaults: plugin
-    jobs:
-      - 'test_plugin_{name}_{branch}'


### PR DESCRIPTION
Some plugins have moved to GitHub Actions and foreman_digitalocean is unmaintained. Not testing this saves wasted compute resources.