### PR TITLE
use both notations of "github-actions"

### DIFF
--- a/theforeman.org/yaml/triggers/github_pr.yaml
+++ b/theforeman.org/yaml/triggers/github_pr.yaml
@@ -5,6 +5,7 @@
       - katello
     white-list:
       - 'github-actions[bot]'
+      - 'github-actions'
     cron: 'H * * * *'
     trigger-phrase: '.*\[test {context}\].*'
     github-hooks: true


### PR DESCRIPTION
just to be sure, the former didn't seem to work, but given that name is
used everywhere, let's keep them so it won't break in future