### PR TITLE
bump timeouts of pipelines with plugins

### DIFF
--- a/theforeman.org/pipelines/release/pipelines/katello.groovy
+++ b/theforeman.org/pipelines/release/pipelines/katello.groovy
@@ -3,7 +3,7 @@ pipeline {
 
     options {
         timestamps()
-        timeout(time: 4, unit: 'HOURS')
+        timeout(time: 5, unit: 'HOURS')
         disableConcurrentBuilds()
         ansiColor('xterm')
     }

--- a/theforeman.org/pipelines/release/pipelines/luna.groovy
+++ b/theforeman.org/pipelines/release/pipelines/luna.groovy
@@ -3,7 +3,7 @@ pipeline {
 
     options {
         timestamps()
-        timeout(time: 4, unit: 'HOURS')
+        timeout(time: 5, unit: 'HOURS')
         disableConcurrentBuilds()
         ansiColor('xterm')
     }

--- a/theforeman.org/pipelines/release/pipelines/plugins-deb.groovy
+++ b/theforeman.org/pipelines/release/pipelines/plugins-deb.groovy
@@ -3,7 +3,7 @@ pipeline {
 
     options {
         timestamps()
-        timeout(time: 3, unit: 'HOURS')
+        timeout(time: 4, unit: 'HOURS')
         disableConcurrentBuilds()
         ansiColor('xterm')
     }

--- a/theforeman.org/pipelines/release/pipelines/plugins-rpm.groovy
+++ b/theforeman.org/pipelines/release/pipelines/plugins-rpm.groovy
@@ -3,7 +3,7 @@ pipeline {
 
     options {
         timestamps()
-        timeout(time: 3, unit: 'HOURS')
+        timeout(time: 4, unit: 'HOURS')
         disableConcurrentBuilds()
         ansiColor('xterm')
     }


### PR DESCRIPTION
the upgrade pipes have been hitting the limits recently, and we should
really not throw away the results in such a case