### PR TITLE
also increase the ansible timeout for job polling

### DIFF
--- a/centos.org/ansible/jenkins_job.yml
+++ b/centos.org/ansible/jenkins_job.yml
@@ -95,7 +95,7 @@
         url: "{{ jenkins_host }}/job/{{ jenkins_job_name }}/{{ poll_result.json.executable.number }}/api/json"
       register: build_job_result
       until: (build_job_result.json is defined) and (not build_job_result.json.building) and (build_job_result.json.result|length > 0)
-      retries: 500
+      retries: 600
       delay: 30
 
     - name: "Create artifacts directory"


### PR DESCRIPTION
in c0a67e48194ef36c211ca366a1366ed9d32a046c we increased the timeout for
jenkins, so it doesn't abort jobs, but forgot to adjust ansible so it
actually continues polling for new results

Fixes: c0a67e48194ef36c211ca366a1366ed9d32a046c