### PR TITLE
Add missing centos8-stream jobs for Katello 4.3

### DIFF
--- a/centos.org/jobs/katello-pipelines.yml
+++ b/centos.org/jobs/katello-pipelines.yml
@@ -42,6 +42,7 @@
       - almalinux8
       - centos7
       - centos8
+      - centos8-stream
     action:
       - install
       - upgrade


### PR DESCRIPTION
Commit 87d05eee1c427763ac79005fc1f5bf9287cdd314 accidentally removed
the centos8-stream testing from Katello 4.3.