### PR TITLE
add Ubuntu 22.04 Jammy to nightly test pipelines

### DIFF
--- a/centos.org/jobs/foreman-pipelines.yml
+++ b/centos.org/jobs/foreman-pipelines.yml
@@ -72,6 +72,7 @@
       - debian10
       - debian11
       - ubuntu2004
+      - ubuntu2204
     version:
       - nightly
     action:

--- a/theforeman.org/pipelines/vars/foreman/nightly.groovy
+++ b/theforeman.org/pipelines/vars/foreman/nightly.groovy
@@ -15,7 +15,8 @@ def pipelines_deb = [
     'install': [
         'debian10',
         'debian11',
-        'ubuntu2004'
+        'ubuntu2004',
+        'ubuntu2204',
     ],
     'upgrade': [
         'debian10',


### PR DESCRIPTION
needs:
- https://github.com/theforeman/foreman-infra/pull/1735
- https://github.com/theforeman/jenkins-jobs/pull/208
- packages actually be built for jammy