### PR TITLE
Removing Verify version and release from Pulpcore,

### DIFF
--- a/theforeman.org/pipelines/test/rpm_packaging.groovy
+++ b/theforeman.org/pipelines/test/rpm_packaging.groovy
@@ -59,7 +59,7 @@ pipeline {
         stage("Verify version and release"){
             when {
                 expression { packages_to_build }
-                expression { ghprbTargetBranch == 'rpm/develop' || ghprbGhRepository == 'theforeman/pulpcore-packaging' }
+                expression { ghprbTargetBranch == 'rpm/develop'}
             }
             steps {
                 script {


### PR DESCRIPTION
This often make cherry-picks ail, I believe that in the context of Foreman by having it to verify on `rpm/develop` is a good way to check if the bump is valid, but for Pulpcore we often do cherry-picks to match a version that is already published in another branch, like in https://github.com/theforeman/pulpcore-packaging/pull/525, when we do multiple cherry-picks for the same package sometimes it fails.

I only see this being valid for pulpcore packaging if we also had a `rpm/develop` there, but this is a talk for the future :smile: .