### PR TITLE
Build Debian plugins on Ubuntu Focal (20.04)

### DIFF
--- a/theforeman.org/pipelines/lib/packaging.groovy
+++ b/theforeman.org/pipelines/lib/packaging.groovy
@@ -71,7 +71,7 @@ def find_changed_debs(diff_range) {
             type: 'plugin',
             name: project,
             path: "${folder}/${project}",
-            operating_system: 'buster'
+            operating_system: 'focal'
         ])
     }
 


### PR DESCRIPTION
Foreman Nightly has dropped Debian Buster support, so building fails.  This changes the OS we build the packages on to Ubuntu Focal, which is supported on all supported Foreman versions and (besides Debian Buster) the oldest Debian-based OS.