### PR TITLE
build plugins on bullseye not focal

### DIFF
--- a/theforeman.org/pipelines/lib/packaging.groovy
+++ b/theforeman.org/pipelines/lib/packaging.groovy
@@ -71,7 +71,7 @@ def find_changed_debs(diff_range) {
             type: 'plugin',
             name: project,
             path: "${folder}/${project}",
-            operating_system: 'focal'
+            operating_system: 'bullseye'
         ])
     }
 


### PR DESCRIPTION
Bundler on focal is broken and doesn't find thor properly.
While we have fixes for that for the built packages, it is still a
problem during building of plugins (as this requires to load the Bundler
library vs using the CLI).

The setup on Bullseye is sane and seems to just work from my tests, so
let's use that. Bullseye should be able to build packages for Foreman
3.2+, which is everything we support these days.