### PR TITLE
Install cicoclient using pip

### DIFF
--- a/centos.org/ansible/ansible.cfg
+++ b/centos.org/ansible/ansible.cfg
@@ -1,5 +1,5 @@
 [defaults]
 # Attempt to load cico Ansible module whether it's installed system-wide or from a virtual environment
-library = /usr/lib/python2.7/site-packages/cicoclient/ansible:$VIRTUAL_ENV/lib/python2.7/site-packages/cicoclient/ansible:/usr/lib/python3.6/site-packages/cicoclient/ansible:$VIRTUAL_ENV/lib/python3.6/site-packages/cicoclient/ansible
+library = $VIRTUAL_ENV/lib/python3.8/site-packages/cicoclient/ansible:/usr/lib/python3.6/site-packages/cicoclient/ansible
 host_key_checking = False
 retry_files_enabled = False

--- a/centos.org/pipelines/lib/foremanCentosJob.groovy
+++ b/centos.org/pipelines/lib/foremanCentosJob.groovy
@@ -19,9 +19,7 @@ pipeline {
                 deleteDir()
                 git url: 'https://github.com/theforeman/forklift.git'
 
-                // old pip doesn't use binary wheels, and we really do not want to compile the otel sdk
-                sh(label: 'update pip', script: 'pip3 install -U pip --user')
-                sh(label: 'pip install', script: '~/.local/bin/pip install opentelemetry-api opentelemetry-sdk opentelemetry-exporter-otlp')
+                sh(label: 'pip install', script: 'pip3.8 install opentelemetry-api opentelemetry-sdk opentelemetry-exporter-otlp cicoclient')
             }
         }
         stage('Provision Node') {


### PR DESCRIPTION
In the most recent cico-workspace container image the Ansible version was updated to ansible-core. This is using Python 3.8 while the python-cicoclient package is installed using Python 3.6.

The intended replacement is duffy, but for now this allows us to provision.

This also changes the pip install command to use pip3.8.

https://github.com/centosci/images/commit/67b9fd58432eda8df20dea1815bd410ef4922bf8