### PR TITLE
Compatibility with ansible-core

### DIFF
--- a/theforeman.org/pipelines/lib/duffy.groovy
+++ b/theforeman.org/pipelines/lib/duffy.groovy
@@ -11,7 +11,8 @@ def provision() {
 }
 
 def fix_ansible_config() {
-    sh(script: "sed -i s/yaml/debug/g ansible.cfg", label: 'fix ansible config')
+    // the yaml stdout callback is gone in ansible-core
+    sh(script: "sed -i /stdout_callback/d ansible.cfg", label: 'fix ansible config')
 }
 
 def deprovision() {


### PR DESCRIPTION
The cico-workspace:latest container has moved to ansible-core. This aims to make provisioning work again. To be used with https://github.com/theforeman/forklift/pull/1547.