### PR TITLE
Revert "Install a forked cicoclient with bugfix"

### DIFF
--- a/centos.org/pipelines/lib/foremanCentosJob.groovy
+++ b/centos.org/pipelines/lib/foremanCentosJob.groovy
@@ -19,7 +19,7 @@ pipeline {
                 deleteDir()
                 git url: 'https://github.com/theforeman/forklift.git'
 
-                sh(label: 'pip install', script: 'pip3.8 install --user opentelemetry-api opentelemetry-sdk opentelemetry-exporter-otlp git+https://github.com/ekohl/python-cicoclient@0.4.7-treat-ssid-as-strings')
+                sh(label: 'pip install', script: 'pip3.8 install --user opentelemetry-api opentelemetry-sdk opentelemetry-exporter-otlp python-cicoclient')
             }
         }
         stage('Provision Node') {


### PR DESCRIPTION
This reverts commit 773f3c6f5e59cf0822cb3b9fe69131f672005713. A patched fork is no longer needed now that the service has the required fixes.