### PR TITLE
Archive Puppetfile.lock in the installer

### DIFF
--- a/theforeman.org/pipelines/release/source/foreman-installer.groovy
+++ b/theforeman.org/pipelines/release/source/foreman-installer.groovy
@@ -35,6 +35,7 @@ pipeline {
                 script {
                     sourcefile_paths = generate_sourcefiles(project_name: project_name, source_type: source_type)
                 }
+                archiveArtifacts(artifacts: 'Puppetfile.lock', allowEmptyArchive: true)
             }
         }
     }


### PR DESCRIPTION
This makes it easier to figure out which modules were used, without having to dive into the console logs.

A draft since this is untested now.