### PR TITLE
don't pass `pipelines` to `runDuffyPipelines`

### DIFF
--- a/theforeman.org/pipelines/release/pipelines/foreman-pipeline.groovy
+++ b/theforeman.org/pipelines/release/pipelines/foreman-pipeline.groovy
@@ -35,7 +35,7 @@ pipeline {
 
             steps {
                 script {
-                    runDuffyPipelines(['foreman-rpm', 'foreman-deb'], foreman_version, pipelines, params.expected_version)
+                    runDuffyPipelines(['foreman-rpm', 'foreman-deb'], foreman_version, params.expected_version)
                 }
             }
         }


### PR DESCRIPTION
it doesn't need the individual pipeline configurations

Fixes: e865f9d9f1f485e09a7eb007cf6b7f01315772fd