### PR TITLE
don't put individual playbooks in own stages

### DIFF
--- a/centos.org/pipelines/lib/foremanDuffyJob.groovy
+++ b/centos.org/pipelines/lib/foremanDuffyJob.groovy
@@ -90,9 +90,7 @@ pipeline {
 
                                 duffy_scp_in('otel_env', 'otel_env', boxname, './')
                                 for(playbook in playbooks) {
-                                    stage(playbook) {
-                                        duffy_ssh("source otel_env && cd forklift && ansible-playbook pipelines/${playBook['pipeline']}/${playbook} ${extra_vars}", boxname, './')
-                                    }
+                                    duffy_ssh("source otel_env && cd forklift && ansible-playbook pipelines/${playBook['pipeline']}/${playbook} ${extra_vars}", boxname, './')
                                 }
                             }
                         }


### PR DESCRIPTION
Jenkins doesn't cope well with parallel stages inside stages when we dynamically generate the list of steps.

If we'd use just `parallel` or `matrix` with a static set of steps, it would work, but we generate things on the fly and this confuses the Blue Ocean view, resulting in only the first stage to be present in the view and thus making it impossible to jump to the failed step if there are any.