### PR TITLE
store remote artifacts in folders like they are generated

### DIFF
--- a/centos.org/ansible/jenkins_job.yml
+++ b/centos.org/ansible/jenkins_job.yml
@@ -85,6 +85,13 @@
         state: directory
       when: jenkins_download_artifacts | bool
 
+    - name: "Create artifacts sub-directories"
+      file:
+        path: "{{ jenkins_artifacts_directory }}/{{ item }}"
+        state: directory
+      loop: "{{ build_job_result.json.artifacts | map(attribute='relativePath') | map('dirname') | unique }}"
+      when: jenkins_download_artifacts | bool
+
     - name: "Fetch remote console log"
       get_url:
         url: "{{ jenkins_host }}/job/{{ jenkins_job_name }}/{{ poll_result.json.executable.number }}/consoleText"
@@ -94,7 +101,7 @@
     - name: "Fetch remote artifacts"
       get_url:
         url: "{{ jenkins_host }}/job/{{ jenkins_job_name }}/{{ poll_result.json.executable.number }}/artifact/{{ item.relativePath }}"
-        dest: "{{ jenkins_artifacts_directory }}/{{ item.fileName }}"
+        dest: "{{ jenkins_artifacts_directory }}/{{ item.relativePath }}"
       loop: "{{ build_job_result.json.artifacts }}"
       when: jenkins_download_artifacts | bool
 


### PR DESCRIPTION
otherwise we might have the same artifact mutliple times (like test results) and those will end up overwriting each other