### PR TITLE
Remove obsolete conditional puppet.rb replacement

### DIFF
--- a/theforeman.org/scripts/test/foreman-proxy.sh
+++ b/theforeman.org/scripts/test/foreman-proxy.sh
@@ -17,10 +17,5 @@ set -x
 
 gem install bundler --no-document
 
-# Puppet environment
-if [ -e $APP_ROOT/bundler.d/puppet.rb ] ; then
-	sed -i "/^\s*gem.*puppet/ s/\$/, '~> $puppet'/" $APP_ROOT/bundler.d/puppet.rb
-fi
-
 bundle install --without=development --jobs=5 --retry=5
 bundle exec rake pkg:generate_source jenkins:unit --trace


### PR DESCRIPTION
Prior to smart-proxy 1.23 there was a `bundler.d/puppet.rb` file where we wanted to pin the version, but this is safe to drop now. The `test_proxy_X_Y_stable` jobs use this script.