### PR TITLE
Add a smart-proxy-stable pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Useful resources:
 | Nightly Package Builder | {git-repo}-{git-branch}-package-release                | foreman-develop-package-release | hammer-cli-katello-master-package-release |
 | CI pipeline             | {repository}-{environment}-{optional-concern}-pipeline | foreman-nightly-rpm-pipeline    | foreman-nightly-deb-pipeline              |
 | Pull Request testing    | {git-repo}-{optional-concern}-pr-test                  | katello-pr-test                 | foreman-packaging-rpm-pr-test             |
+| Branch testing          | {git-repo}-{git-branch}-test                           | foreman-3.5-stable-test         | smart-proxy-3.5-stable-test               |
 
 ## Job configurations
 

--- a/branch-foreman
+++ b/branch-foreman
@@ -8,7 +8,8 @@ if [[ -z $FOREMAN_VERSION ]] || [[ -z $KATELLO_VERSION ]] ; then
 	exit 1
 fi
 
-sed "/foreman_version/ s/nightly/${FOREMAN_VERSION}/" theforeman.org/pipelines/vars/foreman/nightly.groovy > theforeman.org/pipelines/vars/foreman/${FOREMAN_VERSION}.groovy
+sed "/foreman_version/ s/nightly/${FOREMAN_VERSION}/ ; /git_branch/ s/develop/\${foreman_version}-stable/" \
+	theforeman.org/pipelines/vars/foreman/nightly.groovy > theforeman.org/pipelines/vars/foreman/${FOREMAN_VERSION}.groovy
 
 sed -e "/foreman_version/ s/nightly/${FOREMAN_VERSION}/" \
 	-e "/katello_version/ s/nightly/${KATELLO_VERSION}/" \

--- a/theforeman.org/pipelines/lib/stable/smart-proxy.groovy
+++ b/theforeman.org/pipelines/lib/stable/smart-proxy.groovy
@@ -1,0 +1,13 @@
+properties([
+    parameters([
+        gitParameter(branch: '',
+                     defaultValue: git_branch,
+                     description: '',
+                     name: 'BRANCH',
+                     quickFilterEnabled: false,
+                     selectedValue: 'NONE',
+                     sortMode: 'NONE',
+                     tagFilter: '*',
+                     type: 'PT_BRANCH')
+    ])
+])

--- a/theforeman.org/pipelines/test/smart-proxy.groovy
+++ b/theforeman.org/pipelines/test/smart-proxy.groovy
@@ -1,3 +1,11 @@
+def git_checkout = {
+    if (env.ghprbPullId) {
+        ghprb_git_checkout()
+    } else {
+        git branch: "${params.BRANCH}", url: 'https://github.com/theforeman/smart-proxy'
+    }
+}
+
 pipeline {
     agent none
     options {
@@ -19,7 +27,9 @@ pipeline {
             stages {
                 stage('Setup Git Repos') {
                     steps {
-                        ghprb_git_checkout()
+                        script {
+                            git_checkout()
+                        }
                     }
                 }
                 stage('Setup RVM') {
@@ -66,7 +76,9 @@ pipeline {
                 stages {
                     stage('Setup Git Repos') {
                         steps {
-                            ghprb_git_checkout()
+                            script {
+                                git_checkout()
+                            }
                         }
                     }
                     stage('Setup RVM') {

--- a/theforeman.org/pipelines/vars/foreman/3.3.groovy
+++ b/theforeman.org/pipelines/vars/foreman/3.3.groovy
@@ -1,4 +1,5 @@
 def foreman_version = '3.3'
+def git_branch = "${foreman_version}-stable"
 def foreman_client_distros = [
     'el9',
     'el8',

--- a/theforeman.org/pipelines/vars/foreman/3.4.groovy
+++ b/theforeman.org/pipelines/vars/foreman/3.4.groovy
@@ -1,4 +1,5 @@
 def foreman_version = '3.4'
+def git_branch = "${foreman_version}-stable"
 def foreman_client_distros = [
     'el9',
     'el8',

--- a/theforeman.org/pipelines/vars/foreman/3.5.groovy
+++ b/theforeman.org/pipelines/vars/foreman/3.5.groovy
@@ -1,4 +1,5 @@
 def foreman_version = '3.5'
+def git_branch = "${foreman_version}-stable"
 def foreman_client_distros = [
     'el9',
     'el8',

--- a/theforeman.org/pipelines/vars/foreman/nightly.groovy
+++ b/theforeman.org/pipelines/vars/foreman/nightly.groovy
@@ -1,4 +1,5 @@
 def foreman_version = 'nightly'
+def git_branch = "develop"
 def foreman_client_distros = [
     'el9',
     'el8',

--- a/theforeman.org/yaml/jobs/pipeline/foreman-stable-pipelines.yaml
+++ b/theforeman.org/yaml/jobs/pipeline/foreman-stable-pipelines.yaml
@@ -1,0 +1,21 @@
+- job-template:
+    name: 'smart-proxy-{version}-stable-test'
+    project-type: pipeline
+    sandbox: true
+    properties:
+      - github:
+          url: https://github.com/theforeman/smart-proxy
+    dsl:
+      !include-raw:
+        - 'pipelines/vars/foreman/{version}.groovy'
+        - 'pipelines/lib/stable/smart-proxy.groovy{empty}'
+        - 'pipelines/test/smart-proxy.groovy{empty}'
+        - 'pipelines/lib/rvm.groovy{empty}'
+
+- project:
+    name: foreman-stable
+    jobs:
+      - 'smart-proxy-{version}-stable-test'
+    empty: ''
+    version:
+      !include: ../../includes/foreman_versions.yaml.inc


### PR DESCRIPTION
This is intended to replace the `test_proxy_X_Y` jobs with pipelines. This is intended to make the naming more consistent and branching easier. It also works towards phasing out the legacy jobs. Right now it doesn't remove the old ones so I can easily experiment with it.

Also includes a commit that externalizes the testing to a script so it's easy to run it locally.