### PR TITLE
Run the deploy_web job using Ruby 2.7

### DIFF
--- a/theforeman.org/pipelines/deploy/website.groovy
+++ b/theforeman.org/pipelines/deploy/website.groovy
@@ -9,7 +9,7 @@ pipeline {
     }
 
     environment {
-        ruby_version = '2.5'
+        ruby_version = '2.7'
         // Sync to the pivot-point on the web node
         target_path = 'website@web01.osuosl.theforeman.org:rsync_cache/'
         rsync_log = 'deploy-website.log'


### PR DESCRIPTION
Currently it fails to install because bundler dropped Ruby 2.5 support. Rather than pinning bunder, this updates to a current Ruby.

https://github.com/theforeman/theforeman.org/pull/2054 is the equivalent for CI.