### PR TITLE
trigger deb-test-plugins after deb has passed

### DIFF
--- a/theforeman.org/yaml/jobs/pipeline/foreman-release-pipelines.yaml
+++ b/theforeman.org/yaml/jobs/pipeline/foreman-release-pipelines.yaml
@@ -67,6 +67,11 @@
     name: 'foreman-plugins-{version}-deb-test-pipeline'
     project-type: pipeline
     sandbox: true
+    triggers:
+      - reverse:
+          jobs:
+            - foreman-{version}-deb-pipeline
+          result: success
     dsl:
       !include-raw:
         - 'pipelines/vars/foreman/{version}.groovy'


### PR DESCRIPTION
for rpm we do something similar with foreman → katello → luna but for deb we don't trigger plugins regularly