### PR TITLE
Add Ruby 3 testing to Smart Proxy pipelines

### DIFF
--- a/theforeman.org/pipelines/release/source/smart-proxy.groovy
+++ b/theforeman.org/pipelines/release/source/smart-proxy.groovy
@@ -14,9 +14,9 @@ pipeline {
                 git url: git_url, branch: git_ref
             }
         }
-        stage("test ruby-2.7") {
+        stage("test ruby") {
             steps {
-                run_test(ruby: '2.7')
+                run_test(ruby: '2.7', '3.0', '3.1')
             }
         }
         stage('Build and Archive Source') {

--- a/theforeman.org/pipelines/test/smart-proxy.groovy
+++ b/theforeman.org/pipelines/test/smart-proxy.groovy
@@ -67,7 +67,12 @@ pipeline {
                 axes {
                     axis {
                         name 'ruby'
-                        values '2.7'
+                        values '3.1'
+                    }
+                }
+                when {
+                    expression {
+                        ruby_versions.contains(env.ruby)
                     }
                 }
                 environment {
@@ -78,6 +83,10 @@ pipeline {
                         steps {
                             script {
                                 git_checkout()
+                            }
+
+                            dir('foreman') {
+                                git url: "https://github.com/theforeman/foreman", branch: develop, poll: false
                             }
                         }
                     }

--- a/theforeman.org/pipelines/test/smart-proxy.groovy
+++ b/theforeman.org/pipelines/test/smart-proxy.groovy
@@ -67,12 +67,7 @@ pipeline {
                 axes {
                     axis {
                         name 'ruby'
-                        values '3.1'
-                    }
-                }
-                when {
-                    expression {
-                        ruby_versions.contains(env.ruby)
+                        values '2.7', '3.0', '3.1'
                     }
                 }
                 environment {
@@ -83,10 +78,6 @@ pipeline {
                         steps {
                             script {
                                 git_checkout()
-                            }
-
-                            dir('foreman') {
-                                git url: "https://github.com/theforeman/foreman", branch: develop, poll: false
                             }
                         }
                     }


### PR DESCRIPTION
Add Ruby 3 testing to Smart Proxy pipelines

**Requires:** 

This PR has dependecies on `smart-proxy` core and it's plugins PR for ruby 3 upgrade 