### PR TITLE
Remove database parameter to testing & run integration tests on test_develop

### DIFF
--- a/theforeman.org/scripts/test/test_develop.sh
+++ b/theforeman.org/scripts/test/test_develop.sh
@@ -25,11 +25,11 @@ bundle exec rake rubocop
 
 # Database environment
 (
-  sed "s/^test:/development:/; s/database:.*/database: ${gemset}-dev/" $HOME/${database}.db.yaml
+  sed "s/^test:/development:/; s/database:.*/database: ${gemset}-dev/" $HOME/postgresql.db.yaml
   echo
-  sed "s/^test:/production:/; s/database:.*/database: ${gemset}-prod/" $HOME/${database}.db.yaml
+  sed "s/^test:/production:/; s/database:.*/database: ${gemset}-prod/" $HOME/postgresql.db.yaml
   echo
-  sed "s/database:.*/database: ${gemset}-test/" $HOME/${database}.db.yaml
+  sed "s/database:.*/database: ${gemset}-test/" $HOME/postgresql.db.yaml
 ) > $APP_ROOT/config/database.yml
 
 # we need to install node modules for integration tests

--- a/theforeman.org/scripts/test/test_katello.sh
+++ b/theforeman.org/scripts/test/test_katello.sh
@@ -50,9 +50,9 @@ bundle update --jobs=5 --retry=5
 
 # Database environment
 (
-  sed "s/^test:/development:/; s/database:.*/database: ${gemset}-dev/" $HOME/${database}.db.yaml
+  sed "s/^test:/development:/; s/database:.*/database: ${gemset}-dev/" $HOME/postgresql.db.yaml
   echo
-  sed "s/database:.*/database: ${gemset}-test/" $HOME/${database}.db.yaml
+  sed "s/database:.*/database: ${gemset}-test/" $HOME/postgresql.db.yaml
 ) > $APP_ROOT/config/database.yml
 
 # First try to drop the DB, but ignore failure as it might happen with Rails 5

--- a/theforeman.org/scripts/test/test_plugin.sh
+++ b/theforeman.org/scripts/test/test_plugin.sh
@@ -29,9 +29,9 @@ bundle install --without=development --jobs=5 --retry=5
 
 # Database environment
 (
-  sed "s/^test:/development:/; s/database:.*/database: ${gemset}-dev/" $HOME/${database}.db.yaml
+  sed "s/^test:/development:/; s/database:.*/database: ${gemset}-dev/" $HOME/postgresql.db.yaml
   echo
-  sed "s/database:.*/database: ${gemset}-test/" $HOME/${database}.db.yaml
+  sed "s/database:.*/database: ${gemset}-test/" $HOME/postgresql.db.yaml
 ) > $APP_ROOT/config/database.yml
 
 # Create DB first in development as migrate behaviour can change
@@ -62,12 +62,12 @@ tasks="jenkins:unit"
 
 # If the plugin contains integration tests or triggers core integration tests,
 # we need to install node modules and compile webpack
-if [ -d "${PLUGIN_ROOT}/test/integration" ] || [ ${database} = postgresql ]; then
+if [ -d "${PLUGIN_ROOT}/test/integration" ] ; then
   npm install --no-audit
   tasks="webpack:compile $tasks"
 fi
 
-[ ${database} = postgresql ] && tasks="$tasks jenkins:integration"
+tasks="$tasks jenkins:integration"
 bundle exec rake $tasks TESTOPTS="-v" --trace
 
 # Run the DB seeds to verify they work

--- a/theforeman.org/yaml/builders/foreman-plugins-pull-request.yaml
+++ b/theforeman.org/yaml/builders/foreman-plugins-pull-request.yaml
@@ -34,9 +34,9 @@
 
           # Database environment
           (
-            sed "s/^test:/development:/; s/database:.*/database: test-${{gemset}}-dev/" ${{HOME}}/${{database}}.db.yaml
+            sed "s/^test:/development:/; s/database:.*/database: test-${{gemset}}-dev/" ${{HOME}}/postgresql.db.yaml
             echo
-            sed "s/database:.*/database: test-${{gemset}}/" ${{HOME}}/${{database}}.db.yaml
+            sed "s/database:.*/database: test-${{gemset}}/" ${{HOME}}/postgresql.db.yaml
           ) > ${{APP_ROOT}}/config/database.yml
 
           # Create DB first in development as migrate behaviour can change
@@ -61,10 +61,10 @@
 
           # If the plugin contains integration tests or triggers core integration tests,
           # we need to install node modules and compile webpack
-          if [ -d ${{PLUGIN_ROOT}}/test/integration ] || [ ${{database}} = postgresql ]; then
+          if [ -d ${{PLUGIN_ROOT}}/test/integration ] ; then
             npm install --no-audit
             tasks="webpack:compile ${{tasks}}"
           fi
 
-          [ ${{database}} = postgresql ] && tasks="${{tasks}} jenkins:integration"
+          tasks="${{tasks}} jenkins:integration"
           bundle exec rake ${{tasks}} TESTOPTS="-v" --trace

--- a/theforeman.org/yaml/jobs/foreman-plugins-pull-request.yaml
+++ b/theforeman.org/yaml/jobs/foreman-plugins-pull-request.yaml
@@ -24,11 +24,6 @@
           values:
             - '2.7'
       - axis:
-          type: user-defined
-          name: database
-          values:
-            - postgresql
-      - axis:
           type: slave
           name: label
           values:

--- a/theforeman.org/yaml/jobs/test_3_4_stable.yaml
+++ b/theforeman.org/yaml/jobs/test_3_4_stable.yaml
@@ -17,11 +17,6 @@
           values:
             - 2.7
       - axis:
-          type: user-defined
-          name: database
-          values:
-            - postgresql
-      - axis:
           type: label-expression
           name: slave
           values:

--- a/theforeman.org/yaml/jobs/test_3_5_stable.yaml
+++ b/theforeman.org/yaml/jobs/test_3_5_stable.yaml
@@ -17,11 +17,6 @@
           values:
             - 2.7
       - axis:
-          type: user-defined
-          name: database
-          values:
-            - postgresql
-      - axis:
           type: label-expression
           name: slave
           values:

--- a/theforeman.org/yaml/jobs/test_3_6_stable.yaml
+++ b/theforeman.org/yaml/jobs/test_3_6_stable.yaml
@@ -17,11 +17,6 @@
           values:
             - 2.7
       - axis:
-          type: user-defined
-          name: database
-          values:
-            - postgresql
-      - axis:
           type: label-expression
           name: slave
           values:

--- a/theforeman.org/yaml/jobs/test_plugin_matrix.yaml
+++ b/theforeman.org/yaml/jobs/test_plugin_matrix.yaml
@@ -23,10 +23,6 @@
           name: foreman_branch
           default: develop
           description: "Git branch name of Foreman itself, e.g. <pre>develop</pre>"
-      - string:
-          name: dbs
-          default: 'postgresql'
-          description: "Databases to test against"
     concurrent: true
     scm:
       - git:
@@ -42,11 +38,6 @@
           name: ruby
           values:
             - 2.7
-      - axis:
-          type: dynamic
-          name: database
-          values:
-            - dbs
       - axis:
           type: label-expression
           name: slave


### PR DESCRIPTION
The plugin tests were failing because database was not set for some reason I didn't investigate:

```
13:02:33 + sed 's/^test:/development:/; s/database:.*/database: test_plugin_matrix-0-dev/' /home/jenkins/.db.yaml
13:02:33 sed: can't read /home/jenkins/.db.yaml: No such file or directory
```

If we ever pass `database`, the only value we pass is postgresql (the only DB Foreman 2+ supports) so we can drop it.

Also runs integration tests on test_develop. Since c5c1bd6c8e635f87eb4c447f66e64b49ff38b3c7 this code wasn't triggered anymore, but it's actually a good idea to run integration tests.