### PR TITLE
Remove dbs parameter from plugin test

### DIFF
--- a/theforeman.org/yaml/jobs/plugins/foreman_virt_who_configure.yaml
+++ b/theforeman.org/yaml/jobs/plugins/foreman_virt_who_configure.yaml
@@ -1,7 +1,6 @@
 - project:
     name: foreman_virt_who_configure
     defaults: plugin
-    dbs: 'postgresql'
     parameters:
       - string:
           name: branch

--- a/theforeman.org/yaml/jobs/test_plugin.yaml
+++ b/theforeman.org/yaml/jobs/test_plugin.yaml
@@ -25,7 +25,6 @@
             plugin_branch={branch}
             plugin_name={name}
             foreman_branch={foreman_branch}
-            dbs={dbs}
           block: true
     publishers:
       - ircbot_freenode
@@ -35,4 +34,3 @@
     repo: '{name}'
     branch: master
     foreman_branch: develop
-    dbs: 'postgresql'


### PR DESCRIPTION
The database parameter was removed. Somehow this was still remaining, but it's now redundant and generating warnings.

Fixes: ebfdda28aaab0c218b9bceef1fd56575c5dfd425