### PR TITLE
Remove Katello versions eariler than 4.7 per the release process

### DIFF
--- a/centos.org/jobs/katello-pipelines.yml
+++ b/centos.org/jobs/katello-pipelines.yml
@@ -5,7 +5,6 @@
       - 'foreman-pipeline-{type}-{flavor}-{version}'
     empty: ''
     version:
-      - '4.6'
       - '4.7'
       - '4.8'
       - 'nightly'

--- a/theforeman.org/pipelines/test/testKatello.groovy
+++ b/theforeman.org/pipelines/test/testKatello.groovy
@@ -11,26 +11,6 @@ def katello_versions = [
         'foreman': '3.5-stable',
         'ruby': ['2.7']
     ],
-    'KATELLO-4.6': [
-        'foreman': '3.4-stable',
-        'ruby': ['2.7']
-    ],
-    'KATELLO-4.5': [
-        'foreman': '3.3-stable',
-        'ruby': ['2.7']
-    ],
-    'KATELLO-4.4': [
-        'foreman': '3.2-stable',
-        'ruby': ['2.7']
-    ],
-    'KATELLO-4.3': [
-        'foreman': '3.1-stable',
-        'ruby': ['2.7']
-    ],
-    'KATELLO-4.2': [
-        'foreman': '3.0-stable',
-        'ruby': ['2.7']
-    ],
     //Testing of 3.18 to help with better testing of user issue fixes for migration
     'KATELLO-3.18': [
         'foreman': '2.3-stable',


### PR DESCRIPTION
Per this step in the release process:

Remove references to the oldest Katello version from [testKatello.groovy 1](https://github.com/theforeman/jenkins-jobs/blob/master/theforeman.org/pipelines/test/testKatello.groovy) and [katello-pipelines.yml 1](https://github.com/theforeman/jenkins-jobs/blob/master/centos.org/jobs/katello-pipelines.yml).

This PR covers this