### PR TITLE
use pip3.11 to install libraries needed by Ansible

### DIFF
--- a/centos.org/pipelines/lib/foremanDuffyJob.groovy
+++ b/centos.org/pipelines/lib/foremanDuffyJob.groovy
@@ -18,7 +18,7 @@ pipeline {
                 deleteDir()
                 git url: 'https://github.com/theforeman/forklift.git'
 
-                sh(label: 'pip install', script: 'pip3.9 install --user opentelemetry-api opentelemetry-sdk opentelemetry-exporter-otlp duffy[client]')
+                sh(label: 'pip install', script: 'pip3.11 install --user opentelemetry-api opentelemetry-sdk opentelemetry-exporter-otlp duffy[client]')
 
                 setupDuffyClient()
             }


### PR DESCRIPTION
otherwise Ansible can't find them since ansible-core-2.14.2-3 which uses Python 3.11