### PR TITLE
Fix Foreman plugin CI tests without integration tests

### DIFF
--- a/theforeman.org/scripts/test/test_plugin.sh
+++ b/theforeman.org/scripts/test/test_plugin.sh
@@ -64,10 +64,9 @@ tasks="jenkins:unit"
 # we need to install node modules and compile webpack
 if [ -d "${PLUGIN_ROOT}/test/integration" ] ; then
   npm install --no-audit
-  tasks="webpack:compile $tasks"
+  tasks="$tasks jenkins:integration"
 fi
 
-tasks="$tasks jenkins:integration"
 bundle exec rake $tasks TESTOPTS="-v" --trace
 
 # Run the DB seeds to verify they work


### PR DESCRIPTION
Prior to this it only installed NPM packages when the plugin itself had integration tests and then ran webpack:compile, but unconditionally ran jenkins:integration. Now it only runs jenkins:integration if there are plugin integration tests. It no longer runs webpack:compile since jenkins:integration depends on that.

Fixes: ebfdda28aaab ("Remove database parameter to testing")