### PR TITLE
Name multiple SCMs

### DIFF
--- a/theforeman.org/yaml/jobs/foreman-plugins-pull-request.yaml
+++ b/theforeman.org/yaml/jobs/foreman-plugins-pull-request.yaml
@@ -7,14 +7,16 @@
           url: '{repo}'
       - tfm-pull-request-build-discarder
     scm:
-      - git:
+      - name: plugin
+        git:
           url: '{repo}'
           wipe-workspace: true
           basedir: 'plugin'
           branches:
             - '${{ghprbActualCommit}}'
           refspec: '+refs/pull/${{ghprbPullId}}/*:refs/remotes/origin/pr/${{ghprbPullId}}/*'
-      - git:
+      - name: foreman
+        git:
           url: https://github.com/theforeman/foreman
           prune: true
           wipe-workspace: true


### PR DESCRIPTION
This uses the multi-scms plugin[1] to define multiple SCMs for a single job.

[1]: https://plugins.jenkins.io/multiple-scms/