### PR TITLE
Apply Foreman plugin CI integration test fixes to PRs

### DIFF
--- a/theforeman.org/yaml/builders/foreman-plugins-pull-request.yaml
+++ b/theforeman.org/yaml/builders/foreman-plugins-pull-request.yaml
@@ -63,8 +63,7 @@
           # we need to install node modules and compile webpack
           if [ -d ${{PLUGIN_ROOT}}/test/integration ] ; then
             npm install --no-audit
-            tasks="webpack:compile ${{tasks}}"
+            tasks="${{tasks}} jenkins:integration"
           fi
 
-          tasks="${{tasks}} jenkins:integration"
           bundle exec rake ${{tasks}} TESTOPTS="-v" --trace

--- a/theforeman.org/yaml/builders/foreman-plugins-pull-request.yaml
+++ b/theforeman.org/yaml/builders/foreman-plugins-pull-request.yaml
@@ -1,0 +1,70 @@
+- builder:
+    name: plugin-pull-request
+    builders:
+      - shell: |+
+          #!/bin/bash -ex
+
+          rm -rf plugin/
+          git clone {plugin-repo} plugin
+
+          # check out the pull request
+          pushd plugin
+          git fetch --tags --progress {plugin-repo} +refs/pull/${{ghprbPullId}}/*:refs/remotes/origin/pr/${{ghprbPullId}}/*
+          git checkout -f ${{ghprbActualCommit}}
+          popd
+
+          TOP_ROOT=`pwd`
+          APP_ROOT=${{TOP_ROOT}}/foreman
+          PLUGIN_ROOT=${{TOP_ROOT}}/plugin
+
+          cd ${{APP_ROOT}}
+
+          # setup basic settings file
+          cp $APP_ROOT/config/settings.yaml.example $APP_ROOT/config/settings.yaml
+
+          # RVM Ruby environment
+          . /etc/profile.d/rvm.sh
+          # Use a gemset unique to each executor to enable parallel builds
+          gemset=$(echo ${{JOB_NAME}} | cut -d/ -f1)-${{EXECUTOR_NUMBER}}
+          rvm use ruby-${{ruby}}@${{gemset}} --create
+          rvm gemset empty --force
+          gem install bundler --no-document
+
+          bundle install --without development --jobs=5 --retry=5
+
+          # Database environment
+          (
+            sed "s/^test:/development:/; s/database:.*/database: test-${{gemset}}-dev/" ${{HOME}}/postgresql.db.yaml
+            echo
+            sed "s/database:.*/database: test-${{gemset}}/" ${{HOME}}/postgresql.db.yaml
+          ) > ${{APP_ROOT}}/config/database.yml
+
+          # Create DB first in development as migrate behaviour can change
+          bundle exec rake db:drop db:create db:migrate
+
+          # Ensure we don't mention the gem twice in the Gemfile in case it's already mentioned there
+          find Gemfile bundler.d -type f -exec sed -i "/gem ['\"]{plugin-name}['\"]/d" {{}} \;
+
+          # Now let's introduce the plugin
+          echo "gem '{plugin-name}', :path => '${{PLUGIN_ROOT}}'" >> bundler.d/Gemfile.local.rb
+
+          # Plugin specifics
+          [ -e ${{PLUGIN_ROOT}}/gemfile.d/{plugin-name}.rb ] && cat ${{PLUGIN_ROOT}}/gemfile.d/{plugin-name}.rb >> bundler.d/Gemfile.local.rb
+
+          # Update dependencies
+          bundle update --jobs=5 --retry=5
+
+          # Now let's add the plugin migrations
+          bundle exec rake db:migrate
+
+          tasks="jenkins:unit"
+
+          # If the plugin contains integration tests or triggers core integration tests,
+          # we need to install node modules and compile webpack
+          if [ -d ${{PLUGIN_ROOT}}/test/integration ] ; then
+            npm install --no-audit
+            tasks="webpack:compile ${{tasks}}"
+          fi
+
+          tasks="${{tasks}} jenkins:integration"
+          bundle exec rake ${{tasks}} TESTOPTS="-v" --trace

--- a/theforeman.org/yaml/jobs/foreman-plugins-pull-request.yaml
+++ b/theforeman.org/yaml/jobs/foreman-plugins-pull-request.yaml
@@ -8,13 +8,6 @@
       - tfm-pull-request-build-discarder
     scm:
       - git:
-          url: '{repo}'
-          wipe-workspace: true
-          basedir: 'plugin'
-          branches:
-            - '${{ghprbActualCommit}}'
-          refspec: '+refs/pull/${{ghprbPullId}}/*:refs/remotes/origin/pr/${{ghprbPullId}}/*'
-      - git:
           url: https://github.com/theforeman/foreman
           prune: true
           wipe-workspace: true
@@ -42,7 +35,9 @@
           timeout: 120
           write-description: 'Build timed out (after {{0}} minutes). Marking the build as aborted.'
     builders:
-      - test_plugin
+      - plugin-pull-request:
+          plugin-name: '{plugin}'
+          plugin-repo: '{repo}'
     publishers:
       - gemset_cleanup
       - junit:


### PR DESCRIPTION
In the previous patch only the post-merge tests were fixed, but PRs have a copy of the testing script. Reusing the same script was harder than I thought so this does the simple fix.

Fixes: b5831b213227 ("Fix Foreman plugin CI tests without integration tests")