### PR TITLE
Drop SLES 11 pushing in 3.7+ client repo pipelines

### DIFF
--- a/theforeman.org/pipelines/vars/foreman/3.7.groovy
+++ b/theforeman.org/pipelines/vars/foreman/3.7.groovy
@@ -4,8 +4,7 @@ def foreman_client_distros = [
     'el9',
     'el8',
     'el7',
-    'sles12',
-    'sles11'
+    'sles12'
 ]
 def foreman_el_releases = [
     'el8'

--- a/theforeman.org/pipelines/vars/foreman/nightly.groovy
+++ b/theforeman.org/pipelines/vars/foreman/nightly.groovy
@@ -4,8 +4,7 @@ def foreman_client_distros = [
     'el9',
     'el8',
     'el7',
-    'sles12',
-    'sles11'
+    'sles12'
 ]
 def foreman_el_releases = [
     'el8'


### PR DESCRIPTION
I didn't notice this on nightly since we still have some repos there, but on Foreman 3.7 it fails hard.