### PR TITLE
Add RPM PR test job for Copr

### DIFF
--- a/theforeman.org/pipelines/lib/copr.groovy
+++ b/theforeman.org/pipelines/lib/copr.groovy
@@ -1,0 +1,22 @@
+def status_copr_links(repo) {
+    if(fileExists('copr_build_info')) {
+        def build_info_files = sh(returnStdout: true, script: "ls copr_build_info/", label: "copr build info").trim().split(' ')
+
+        for(String build_info_file: build_info_files) {
+            build_info_yaml = readYaml(file: "copr_build_info/${build_info_file}")
+
+            for(Map build_info: build_info_yaml['results']) {
+                githubNotify(
+                    credentialsId: 'github-login',
+                    account: 'theforeman',
+                    repo: repo,
+                    sha: "${ghprbActualCommit}",
+                    context: "copr/${build_info_file}-${build_info['chroot']}",
+                    description: "Copr build",
+                    status: build_info["failed"] ? 'FAILURE' : 'SUCCESS',
+                    targetUrl: build_info['build_urls'][0]
+                )
+            }
+        }
+    }
+}

--- a/theforeman.org/pipelines/release/foreman_packaging_rpm_copr_release.groovy
+++ b/theforeman.org/pipelines/release/foreman_packaging_rpm_copr_release.groovy
@@ -1,0 +1,88 @@
+def packages_to_build
+
+pipeline {
+    agent { label 'rpmbuild' }
+
+    options {
+        timestamps()
+        timeout(time: 4, unit: 'HOURS')
+        disableConcurrentBuilds()
+        ansiColor('xterm')
+    }
+
+    stages {
+        stage('Clone Packaging') {
+            steps {
+                script {
+                    foreman_branch = foreman_version == 'nightly' ? "rpm/develop" : "rpm/${foreman_version}"
+                }
+
+                checkout([
+                    $class : 'GitSCM',
+                    branches : [[name: "*/${foreman_branch}"]],
+                    extensions: [[$class: 'CleanCheckout']],
+                    userRemoteConfigs: [
+                        [url: 'https://github.com/theforeman/foreman-packaging']
+                    ]
+                ])
+
+            }
+        }
+        stage('Find packages') {
+            steps {
+                copyArtifacts(projectName: env.JOB_NAME, optional: true)
+
+                script {
+
+                    if (fileExists('commit')) {
+
+                        commit = readFile(file: 'commit').trim()
+                        packages_to_build = find_changed_packages("${commit}..HEAD")
+
+                    } else {
+
+                        packages_to_build = []
+
+                    }
+                }
+            }
+        }
+        stage('Release Build Packages') {
+            when {
+                expression { packages_to_build != [] }
+            }
+            steps {
+
+                setup_obal()
+
+                withCredentials([file(credentialsId: 'theforeman-bot-copr', variable: 'copr_config')]) {
+                    obal(
+                        action: "release",
+                        extraVars: [
+                            'build_package_build_system': 'copr',
+                            'build_package_copr_config': copr_config,
+                        ],
+                        packages: packages_to_build
+                    )
+                }
+
+            }
+        }
+    }
+
+    post {
+        success {
+            archive_git_hash()
+        }
+        failure {
+            notifyDiscourse(
+              env,
+              "${env.JOB_NAME} failed for ${packages_to_build.join(',')}",
+              "Foreman RPM packaging release job failed: ${env.BUILD_URL}"
+            )
+        }
+        cleanup {
+            deleteDir()
+        }
+    }
+}

--- a/theforeman.org/pipelines/test/rpm_copr_packaging.groovy
+++ b/theforeman.org/pipelines/test/rpm_copr_packaging.groovy
@@ -1,0 +1,170 @@
+def packages_to_build
+def packages = [:]
+def VERCMP_NEWER = 12
+def VERCMP_OLDER = 11
+def VERCMP_EQUAL = 0
+
+pipeline {
+    agent { label 'rpmbuild' }
+
+    options {
+        timestamps()
+        timeout(time: 4, unit: 'HOURS')
+        ansiColor('xterm')
+        buildDiscarder(logRotator(daysToKeepStr: '7'))
+    }
+
+    stages {
+        stage('Clone Packaging') {
+            steps {
+
+                deleteDir()
+                ghprb_git_checkout()
+                setup_obal()
+
+            }
+        }
+
+        stage('Find Packages to Build') {
+            steps {
+
+                script {
+                    packages_to_build = find_changed_packages("origin/${ghprbTargetBranch}")
+
+                    update_build_description_from_packages(packages_to_build)
+                }
+
+            }
+        }
+
+        stage('Lint Spec') {
+            when {
+                expression { packages_to_build }
+            }
+            steps {
+
+                script {
+                    for(int i = 0; i < packages_to_build.size(); i++) {
+                        def index = i
+                        packages[packages_to_build[index]] = {
+                            obal(action: "lint", packages: packages_to_build[index])
+                        }
+                    }
+
+                    parallel packages
+                }
+            }
+        }
+
+        stage("Verify version and release"){
+            when {
+                expression { packages_to_build }
+                expression { ghprbTargetBranch == 'rpm/develop'}
+            }
+            steps {
+                script {
+
+                    for(int i = 0; i < packages_to_build.size(); i++) {
+                        package_name = packages_to_build[i]
+                        spec_pattern = "packages/**/${package_name}.spec"
+
+                        old_spec_path = find_deleted_files("origin/${env.ghprbTargetBranch}", spec_pattern)
+                        if (! old_spec_path) {
+                            old_spec_path = find_changed_files("origin/${env.ghprbTargetBranch}", spec_pattern)
+                        }
+
+
+                        if (old_spec_path) {
+                            new_spec_path = find_added_or_changed_files("origin/${env.ghprbTargetBranch}", spec_pattern)
+                            if (old_spec_path != new_spec_path) {
+                              continue
+                            }
+
+                            sh(script: "git checkout origin/${env.ghprbTargetBranch}", label: "git checkout target_branch")
+                            old_version = query_rpmspec(old_spec_path, '%{VERSION}')
+                            old_release = query_rpmspec(old_spec_path, '%{RELEASE}')
+
+                            sh(script: "git checkout -", label: "git checkout source_branch")
+                            new_version = query_rpmspec(new_spec_path, '%{VERSION}')
+                            new_release = query_rpmspec(new_spec_path, '%{RELEASE}')
+
+                            compare_version = sh(
+                              script: "rpmdev-vercmp ${old_version} ${new_version}",
+                              returnStatus: true,
+                              label: "rpmdev-vercmp"
+                            )
+
+                            compare_release = sh(
+                              script: "rpmdev-vercmp ${old_release} ${new_release}",
+                              returnStatus: true,
+                              label: "rpmdev-vercmp"
+                            )
+
+                            compare_new_to_one = sh(
+                              script: "rpmdev-vercmp 1 ${new_release}",
+                              returnStatus: true,
+                              label: "rpmdev-vercmp"
+                            )
+
+                            if (compare_version != VERCMP_EQUAL && (compare_new_to_one == VERCMP_OLDER || compare_new_to_one == VERCMP_EQUAL)) {
+                                echo "New version and release is reset to 1 for ${package_name}"
+                            } else if (compare_version != VERCMP_EQUAL && compare_new_to_one == VERCMP_NEWER) {
+                                // new version, but release was not reset
+                                sh """
+                                    echo 'Version updated but release was not reset back to 1 for ${package_name}"'
+                                    exit 1
+                                """
+                            } else if (compare_version == VERCMP_EQUAL && compare_release == VERCMP_NEWER) {
+                                echo "Version remained the same and release is reset to 1 for ${package_name}"
+                            } else {
+                                sh """
+                                    echo 'Version or release needs updating for ${package_name}"'
+                                    exit 1
+                                """
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        stage('Scratch Build Packages') {
+            when {
+                expression { packages_to_build }
+            }
+            steps {
+
+                withCredentials([file(credentialsId: 'theforeman-bot-copr', variable: 'copr_config')]) {
+                    obal(
+                        action: "scratch",
+                        extraVars: [
+                            'build_package_build_system': 'copr',
+                            'build_package_download_rpms': 'True',
+                            'build_package_archive_build_info': 'True',
+                            'build_package_copr_config': copr_config,
+                        ],
+                        packages: packages_to_build
+                    )
+                }
+
+            }
+        }
+
+        stage('Repoclosure') {
+            when {
+                expression { packages_to_build }
+            }
+            steps {
+
+                obal(action: "repoclosure", packages: packages_to_build)
+
+            }
+        }
+    }
+
+    post {
+        always {
+            status_copr_links(ghprbGhRepository.split('/')[1])
+        }
+    }
+}

--- a/theforeman.org/yaml/jobs/packaging/foreman-packaging-rpm-pr-test.yaml
+++ b/theforeman.org/yaml/jobs/packaging/foreman-packaging-rpm-pr-test.yaml
@@ -18,3 +18,23 @@
         - pipelines/lib/git.groovy
         - pipelines/lib/ansible.groovy
         - pipelines/lib/obal.groovy
+
+- job:
+    name: foreman-packaging-rpm-copr-pr-test
+    project-type: pipeline
+    concurrent: true
+    sandbox: true
+    properties:
+      - github:
+          url: https://github.com/theforeman/foreman-packaging
+    triggers:
+      - github_pr_rpm:
+          context: 'rpm-copr'
+    dsl:
+      !include-raw:
+        - pipelines/test/rpm_copr_packaging.groovy
+        - pipelines/lib/packaging.groovy
+        - pipelines/lib/copr.groovy
+        - pipelines/lib/git.groovy
+        - pipelines/lib/ansible.groovy
+        - pipelines/lib/obal.groovy

--- a/theforeman.org/yaml/jobs/release/foreman-packaging-rpm-release.yaml
+++ b/theforeman.org/yaml/jobs/release/foreman-packaging-rpm-release.yaml
@@ -34,3 +34,31 @@
     empty: ''
     version:
       - 'nightly'
+
+- job-template:
+    name: 'foreman-packaging-rpm-copr-{version}-release'
+    project-type: pipeline
+    sandbox: true
+    concurrent: false
+    properties:
+      - github:
+          url: https://github.com/theforeman/foreman-packaging
+    triggers:
+        - github
+    dsl:
+      !include-raw:
+        - 'pipelines/vars/foreman/{version}.groovy'
+        - 'pipelines/release/foreman_packaging_rpm_copr_release.groovy{empty}'
+        - 'pipelines/lib/git.groovy{empty}'
+        - 'pipelines/lib/ansible.groovy{empty}'
+        - 'pipelines/lib/obal.groovy{empty}'
+        - 'pipelines/lib/packaging.groovy{empty}'
+        - 'pipelines/lib/foreman_infra.groovy{empty}'
+
+- project:
+    name: foreman-packaging-rpm-copr-nightly
+    jobs:
+      - 'foreman-packaging-rpm-copr-{version}-release'
+    empty: ''
+    version:
+      - 'nightly'


### PR DESCRIPTION
This is in conjunction with:

 * https://github.com/theforeman/foreman-packaging/pull/9290
 * https://github.com/theforeman/obal/pull/344

The goal is to enable a scratch build for packaging PRs against Copr so that we can test and hone the workflow before starting to then perform release builds into Copr.