### PR TITLE
Drop smart_proxy_dynflow PR test

### DIFF
--- a/theforeman.org/yaml/jobs/smart-proxy-plugin.yaml
+++ b/theforeman.org/yaml/jobs/smart-proxy-plugin.yaml
@@ -45,7 +45,6 @@
       - dns_infoblox
       - discovery:
           branch: develop # have to be the special child
-      - dynflow
       - monitoring
       - omaha
       - openscap

--- a/theforeman.org/yaml/jobs/tests/smart-proxy-plugin-pr-test.yaml
+++ b/theforeman.org/yaml/jobs/tests/smart-proxy-plugin-pr-test.yaml
@@ -23,7 +23,6 @@
       - dhcp_remote_isc
       - discovery
       - dns_infoblox
-      - dynflow
       - monitoring
       - omaha
       - pulp


### PR DESCRIPTION
I was reviewing https://github.com/theforeman/smart_proxy_dynflow/pull/123 and noticed at this point the smart_proxy_dynflow repository runs the same set of tests in Github Actions and Jenkins. I feel we can drop this duplication in Jenkins.