### PR TITLE
Remove EL8 pipeline for Pulpcore 3.28

### DIFF
--- a/theforeman.org/pipelines/vars/pulpcore/3.28.groovy
+++ b/theforeman.org/pipelines/vars/pulpcore/3.28.groovy
@@ -3,7 +3,6 @@ def pulpcore_distros = ['el8', 'el9']
 def packaging_branch = 'rpm/3.28'
 def pipelines = [
     'pulpcore': [
-        'centos8-stream',
         'centos9-stream'
     ]
 ]


### PR DESCRIPTION
Pulp installer defaults to PostgreSQL 10 on EL8, Pulpcore 3.28 needs PGSQL 12+.