### PR TITLE
Remove jobs for foreman_openscap

### DIFF
--- a/theforeman.org/yaml/jobs/foreman-plugins-pull-request.yaml
+++ b/theforeman.org/yaml/jobs/foreman-plugins-pull-request.yaml
@@ -54,8 +54,6 @@
           repo: 'https://github.com/theforeman/foreman_discovery'
       - foreman_host_extra_validator:
           repo: 'https://github.com/theforeman/foreman_host_extra_validator'
-      - foreman_openscap:
-          repo: 'https://github.com/theforeman/foreman_openscap'
       - foreman_setup:
           repo: 'https://github.com/theforeman/foreman_setup'
       - foreman_templates:

--- a/theforeman.org/yaml/jobs/plugins/foreman_openscap.yaml
+++ b/theforeman.org/yaml/jobs/plugins/foreman_openscap.yaml
@@ -1,6 +1,0 @@
-- project:
-    name: foreman_openscap
-    repo: foreman_openscap
-    defaults: plugin
-    jobs:
-      - 'test_plugin_{name}_{branch}'


### PR DESCRIPTION
There is no longer use in jenkins job: https://github.com/theforeman/foreman_openscap/pull/545#issuecomment-1737403073

Leaving job for smart_proxy_openscap since we don't have it covered via Github Actions.