### PR TITLE
Use checksum to detect RPM changes and drop the use of --archive

### DIFF
--- a/theforeman.org/pipelines/lib/packaging.groovy
+++ b/theforeman.org/pipelines/lib/packaging.groovy
@@ -479,7 +479,7 @@ def rsync_yum(user, ssh_key, collection, target, version) {
 
         sh """
             export RSYNC_RSH="ssh -i ${ssh_key}"
-            /usr/bin/rsync --archive --verbose --partial --one-file-system --delete-after ${collection}/${version} ${target_path}
+            /usr/bin/rsync --checksum --perms --recursive --links --verbose --partial --one-file-system --delete-after ${collection}/${version} ${target_path}
         """
     }
 }


### PR DESCRIPTION
The --archive option includes --times implicitly that preserves modification time and results in all RPMs being thought of as changed. Instead we explicitly define the options that are included in --archive and drop the use of --times.