### PR TITLE
rsync foreman and katello to the correct production locations from st…

### DIFF
--- a/theforeman.org/pipelines/lib/release.groovy
+++ b/theforeman.org/pipelines/lib/release.groovy
@@ -42,7 +42,17 @@ void mash(collection, version) {
 }
 
 void push_staging_rpms(repo_src, repo_dest, version, distro, keep_old_files = false) {
-    push_rpms_direct("${repo_src}/${distro}", "${repo_dest}/${version}/${distro}", !keep_old_files, keep_old_files, true)
+    if (repo_dest == 'foreman') {
+        destination = "releases/${version}/${distro}"
+    } else if (repo_dest == 'katello') {
+        destination = "katello/${version}/katello/${distro}"
+    } else if (repo_dest == 'candlepin') {
+        destination = "katello/${version}/candlepin/${distro}"
+    } else {
+        destination = "${repo_dest}/${version}/${distro}"
+    }
+
+    push_rpms_direct("${repo_src}/${distro}", destination, !keep_old_files, keep_old_files, true)
 }
 
 void push_foreman_staging_rpms(repo_type, version, distro) {


### PR DESCRIPTION
…agingyum

The Foreman and Katello repositories, when rsync from stagingyum need to have their destinations specified since it is not a 1-1 mapping between the two structures.

https://github.com/theforeman/foreman-infra/issues/1937 aims to address this longer term