### PR TITLE
Remove Verify Version and Release from Pulp Packaging

### DIFF
--- a/theforeman.org/pipelines/test/rpm_packaging.groovy
+++ b/theforeman.org/pipelines/test/rpm_packaging.groovy
@@ -59,7 +59,7 @@ pipeline {
         stage("Verify version and release"){
             when {
                 expression { packages_to_build }
-                expression { ghprbTargetBranch == 'rpm/develop'}
+                expression { ghprbTargetBranch == 'rpm/develop' && ghprbGhRepository == 'theforeman/foreman-packaging'}
             }
             steps {
                 script {


### PR DESCRIPTION
We removed this from Pulpcore with #236 , now we have rpm/develop as well on pulpcore-packaging, addning another condition to verify the version only for foreman-packaging