### PR TITLE
Use artifacts from the upstream job, if possible

### DIFF
--- a/theforeman.org/pipelines/lib/packaging.groovy
+++ b/theforeman.org/pipelines/lib/packaging.groovy
@@ -259,7 +259,7 @@ def setup_sources_core(project, os, version, repoowner, pull_request = false) {
         def build_vars = read_build_vars(project)
         if (version == 'nightly') {
             if (build_vars['source_location']) {
-                copyArtifacts(projectName: build_vars['source_location'], excludes: 'package-lock.json', flatten: true)
+                copyArtifacts(projectName: build_vars['source_location'], excludes: 'package-lock.json', flatten: true, selector: upstream(fallbackToLastSuccessful: true))
                 sh(script: "mv *.tar.bz2 ${project}_${package_version}.orig.tar.bz2", label: "rename tarball")
                 last_commit = readFile('commit').trim()
             } else {

--- a/theforeman.org/pipelines/release/foreman-x-develop-release.groovy
+++ b/theforeman.org/pipelines/release/foreman-x-develop-release.groovy
@@ -31,7 +31,7 @@ pipeline {
                             steps {
                                 script {
                                     artifact_path = "${pwd()}/artifacts"
-                                    copyArtifacts(projectName: source_project_name, target: artifact_path)
+                                    copyArtifacts(projectName: source_project_name, target: artifact_path, selector: upstream(fallbackToLastSuccessful: true))
                                     commit_hash = readFile("${artifact_path}/commit")
                                 }
                             }
@@ -77,7 +77,7 @@ pipeline {
                             steps {
                                 script {
                                     artifact_path = "${pwd()}/artifacts"
-                                    copyArtifacts(projectName: source_project_name, target: artifact_path)
+                                    copyArtifacts(projectName: source_project_name, target: artifact_path, selector: upstream(fallbackToLastSuccessful: true))
                                     commit_hash = readFile("${artifact_path}/commit")
                                 }
                             }


### PR DESCRIPTION
We've seen multiple times that a package release job runs, but doesn't use the latest source. My theory is that there's a race condition between declaring the last source release job as last successful and the package release job running.

The Copy Artifact Plugin has an [option for the selector](https://www.jenkins.io/doc/pipeline/steps/copyartifact/). That can be set to upstream with a fallback to the last successful. That would mean that when a source release job triggers a package release job, the triggering job is the upstream. If there is none (like with a manual run), then it should fall back to the last successful.

I'm unsure about the syntax, but https://stackoverflow.com/questions/53820503/how-to-copy-artifacts-from-other-jenkins-job-from-a-pipeline/53821560#53821560 suggests the `selector: upstream()` part is correct and I'm assuming the option is passed this way.