### PR TITLE
For Ruby 2.7 tests use dedicated bundler version

### DIFF
--- a/theforeman.org/pipelines/lib/rvm.groovy
+++ b/theforeman.org/pipelines/lib/rvm.groovy
@@ -15,6 +15,11 @@ def gemset(name = null) {
 
 def configureRVM(ruby, name = '', bundler_version = null) {
     emptyGemset(ruby, name)
+
+    if (ruby == '2.7') {
+        bundler_version = '2.4.22'
+    }
+
     if (bundler_version) {
         withRVM(["gem install bundler -v '${bundler_version}' --no-document"], ruby, name)
     } else {


### PR DESCRIPTION
Bundler 2.4.22 is last version to support Ruby 2.7 and needs to be directly installed to prevent an error resolving the supported version. This requirement occurred with the release of bundler 2.5.0.