### PR TITLE
Drop DISTRO env var for foreman-selinux

### DIFF
--- a/theforeman.org/pipelines/release/source/foreman-selinux.groovy
+++ b/theforeman.org/pipelines/release/source/foreman-selinux.groovy
@@ -20,10 +20,9 @@ pipeline {
         stage("Build for rhel7") {
             steps {
                 script {
-                    distro = 'rhel7'
                     instprefix = pwd(tmp: true)
                 }
-                sh "make INSTPREFIX=${instprefix}/${distro} DISTRO=${distro}"
+                sh "make INSTPREFIX=${instprefix}"
             }
         }
         stage('Build and Archive Source') {


### PR DESCRIPTION
Since Foreman 3.6 (https://projects.theforeman.org/issues/35971) this variable isn't used anymore.