### PR TITLE
Record RuboCop issues for Katello

### DIFF
--- a/theforeman.org/pipelines/test/foreman/katello.groovy
+++ b/theforeman.org/pipelines/test/foreman/katello.groovy
@@ -58,7 +58,12 @@ pipeline {
                     stage('rubocop') {
                         steps {
                             dir('foreman') {
-                                withRVM(['bundle exec rake katello:rubocop TESTOPTS="-v" --trace'], ruby)
+                                withRVM(["bundle exec rubocop --format progress --out ${env.WORKSPACE}/rubocop.log --format progress ${env.WORKSPACE}"], ruby)
+                            }
+                        }
+                        post {
+                            always {
+                                recordIssues tool: ruboCop(pattern: "${env.WORKSPACE}/rubocop.log"), enabledForFailure: true
                             }
                         }
                     }

--- a/theforeman.org/pipelines/test/testKatello.groovy
+++ b/theforeman.org/pipelines/test/testKatello.groovy
@@ -116,7 +116,12 @@ pipeline {
                     stage('rubocop') {
                         steps {
                             dir('foreman') {
-                                withRVM(['bundle exec rake katello:rubocop TESTOPTS="-v" --trace'], ruby)
+                                withRVM(["bundle exec rubocop --format progress --out ${env.WORKSPACE}/rubocop.log --format progress ${env.WORKSPACE}"], ruby)
+                            }
+                        }
+                        post {
+                            always {
+                                recordIssues tool: ruboCop(pattern: "${env.WORKSPACE}/rubocop.log"), enabledForFailure: true
                             }
                         }
                     }


### PR DESCRIPTION
This changes the invocation to directly call RuboCop instead of relying on a rake task. This is copied from smart-proxy.groovy.

Interstingly enough, it doesn't use the katello:rubocop:jenkins task that also exists.

I'm not 100% sure about the env.WORKSPACE part, but we need to point it to the actual checkout and I believe that's the right variable.