### PR TITLE
Use correct braces in smart-proxy-plugin script

### DIFF
--- a/theforeman.org/yaml/builders/smart-proxy-plugin.yaml
+++ b/theforeman.org/yaml/builders/smart-proxy-plugin.yaml
@@ -13,7 +13,7 @@
           rvm gemset empty --force
           set -x
 
-          if [ "${{ruby}}" = '2.7' ]
+          if [ "${ruby}" = '2.7' ]
           then
               gem install bundler -v 2.4.22 --no-document
           else


### PR DESCRIPTION
These are variables that are replaced in Jenkins templating, not bash.

Fixes: f164a3f291045dd45fac4dd560421f243af1fbc3 ("Use bundler 2.4.22 in ruby 2.7 environments")