### PR TITLE
Fix substitution syntax

### DIFF
--- a/theforeman.org/yaml/builders/foreman-plugins-pull-request.yaml
+++ b/theforeman.org/yaml/builders/foreman-plugins-pull-request.yaml
@@ -29,7 +29,7 @@
           rvm use ruby-${{ruby}}@${{gemset}} --create
           rvm gemset empty --force
           
-          if [ "${{ruby}}" = '2.7' ]
+          if [ "${ruby}" = '2.7' ]
           then
               gem install bundler -v 2.4.22 --no-document
           else

--- a/theforeman.org/yaml/builders/smart-proxy-plugin.yaml
+++ b/theforeman.org/yaml/builders/smart-proxy-plugin.yaml
@@ -13,7 +13,7 @@
           rvm gemset empty --force
           set -x
 
-          if [ "${{ruby}}" = '2.7' ]
+          if [ "${ruby}" = '2.7' ]
           then
               gem install bundler -v 2.4.22 --no-document
           else


### PR DESCRIPTION
To fix errors like
```
/tmp/jenkins415375971260303110.sh: line 12: ${{ruby}}: bad substitution
```

seen in https://ci.theforeman.org/job/smart-proxy-openscap-pull-request/60/ruby=2.7/console