### PR TITLE
Drop Ruby 2.5 testing

### DIFF
--- a/theforeman.org/pipelines/test/foreman/unit.groovy
+++ b/theforeman.org/pipelines/test/foreman/unit.groovy
@@ -17,7 +17,7 @@ pipeline {
                 axes {
                     axis {
                         name 'ruby'
-                        values '2.7', '2.5'
+                        values '2.7'
                     }
                 }
                 when {

--- a/theforeman.org/pipelines/test/foreman/vars.groovy
+++ b/theforeman.org/pipelines/test/foreman/vars.groovy
@@ -26,18 +26,6 @@ def foreman_integration_versions = [
     '3.4-stable': [
         'ruby': ['2.7'],
         'katello': 'KATELLO-4.6'
-    ],
-    '3.3-stable': [
-        'ruby': ['2.7'],
-        'katello': 'KATELLO-4.5'
-    ],
-    '3.2-stable': [
-        'ruby': ['2.7'],
-        'katello': 'KATELLO-4.4'
-    ],
-    '3.1-stable': [
-        'ruby': ['2.7'],
-        'katello': 'KATELLO-4.3'
     ]
 ]
 
@@ -66,15 +54,6 @@ def foreman_unit_versions = [
     ],
     '3.4-stable': [
         'ruby': ['2.7']
-    ],
-    '3.3-stable': [
-        'ruby': ['2.7', '2.5']
-    ],
-    '3.2-stable': [
-        'ruby': ['2.7', '2.5']
-    ],
-    '3.1-stable': [
-        'ruby': ['2.7', '2.5']
     ]
 ]
 

--- a/theforeman.org/pipelines/test/testKatello.groovy
+++ b/theforeman.org/pipelines/test/testKatello.groovy
@@ -26,28 +26,7 @@ def katello_versions = [
     'KATELLO-4.6': [
         'foreman': '3.4-stable',
         'ruby': ['2.7']
-    ],
-    'KATELLO-4.5': [
-        'foreman': '3.3-stable',
-        'ruby': ['2.7']
-    ],
-    'KATELLO-4.4': [
-        'foreman': '3.2-stable',
-        'ruby': ['2.7']
-    ],
-    'KATELLO-4.3': [
-        'foreman': '3.1-stable',
-        'ruby': ['2.7']
-    ],
-    'KATELLO-4.2': [
-        'foreman': '3.0-stable',
-        'ruby': ['2.7']
-    ],
-    //Testing of 3.18 to help with better testing of user issue fixes for migration
-    'KATELLO-3.18': [
-        'foreman': '2.3-stable',
-        'ruby': ['2.5']
-    ],
+    ]
 ]
 
 def ruby_versions = katello_versions[ghprbTargetBranch]['ruby']
@@ -69,7 +48,7 @@ pipeline {
                 axes {
                     axis {
                         name 'ruby'
-                        values '2.5', '2.7'
+                        values '2.7'
                     }
                 }
                 when {


### PR DESCRIPTION
These versions are long end of life and shouldn't be running anymore.  This allows us to clean up Ruby 2.5 from our Jenkins nodes.