### PR TITLE
only collect report.tar* from smoker, not individual files

### DIFF
--- a/centos.org/pipelines/lib/foremanDuffyJob.groovy
+++ b/centos.org/pipelines/lib/foremanDuffyJob.groovy
@@ -143,7 +143,7 @@ pipeline {
             archiveArtifacts artifacts: 'debug/**/*.tap', allowEmptyArchive: true
             archiveArtifacts artifacts: 'debug/**/*.tar.xz', allowEmptyArchive: true
             archiveArtifacts artifacts: 'debug/**/*.xml', allowEmptyArchive: true
-            archiveArtifacts artifacts: 'debug/**/report/**', allowEmptyArchive: true
+            archiveArtifacts artifacts: 'debug/**/report.tar*', allowEmptyArchive: true
             archiveArtifacts artifacts: 'debug/**/foreman-backup/**', allowEmptyArchive: true
 
             step([$class: "TapPublisher", testResults: "debug/**/*.tap"])


### PR DESCRIPTION
this is much faster and users can unarchive on their own