### PR TITLE
Drop most Foreman plugin tests

### DIFF
--- a/theforeman.org/yaml/jobs/foreman-plugins-pull-request.yaml
+++ b/theforeman.org/yaml/jobs/foreman-plugins-pull-request.yaml
@@ -46,25 +46,9 @@
 - project:
     name: foreman-plugin-pull-request
     plugin:
-      - foreman_bootdisk:
-          repo: 'https://github.com/theforeman/foreman_bootdisk'
       - foreman_default_hostgroup:
           repo: 'https://github.com/theforeman/foreman_default_hostgroup'
-      - foreman_discovery:
-          repo: 'https://github.com/theforeman/foreman_discovery'
-      - foreman_host_extra_validator:
-          repo: 'https://github.com/theforeman/foreman_host_extra_validator'
-      - foreman_openscap:
-          repo: 'https://github.com/theforeman/foreman_openscap'
       - foreman_setup:
           repo: 'https://github.com/theforeman/foreman_setup'
-      - foreman_templates:
-          repo: 'https://github.com/theforeman/foreman_templates'
-      - foreman_userdata:
-          repo: 'https://github.com/theforeman/foreman_userdata'
-      - puppetdb_foreman:
-          repo: 'https://github.com/theforeman/puppetdb_foreman'
-      - foreman_kubevirt:
-          repo: 'https://github.com/theforeman/foreman_kubevirt.git'
     jobs:
       - '{plugin}-pull-request'

--- a/theforeman.org/yaml/jobs/plugins/foreman_discovery.yaml
+++ b/theforeman.org/yaml/jobs/plugins/foreman_discovery.yaml
@@ -1,8 +1,0 @@
-- project:
-    name: foreman_discovery
-    defaults: plugin
-    branch:
-      - develop:
-          foreman_branch: develop
-    jobs:
-      - 'test_plugin_{name}_{branch}'

--- a/theforeman.org/yaml/jobs/plugins/foreman_host_extra_validator.yaml
+++ b/theforeman.org/yaml/jobs/plugins/foreman_host_extra_validator.yaml
@@ -1,8 +1,0 @@
-- project:
-    name: foreman_host_extra_validator
-    defaults: plugin
-    branch:
-      - master:
-          foreman_branch: develop
-    jobs:
-      - 'test_plugin_{name}_{branch}'

--- a/theforeman.org/yaml/jobs/plugins/foreman_kubevirt.yaml
+++ b/theforeman.org/yaml/jobs/plugins/foreman_kubevirt.yaml
@@ -1,8 +1,0 @@
-- project:
-    name: foreman_kubevirt
-    defaults: plugin
-    branch:
-      - master:
-          foreman_branch: develop
-    jobs:
-      - 'test_plugin_{name}_{branch}'

--- a/theforeman.org/yaml/jobs/plugins/foreman_openscap.yaml
+++ b/theforeman.org/yaml/jobs/plugins/foreman_openscap.yaml
@@ -1,6 +1,0 @@
-- project:
-    name: foreman_openscap
-    repo: foreman_openscap
-    defaults: plugin
-    jobs:
-      - 'test_plugin_{name}_{branch}'

--- a/theforeman.org/yaml/jobs/plugins/foreman_templates.yaml
+++ b/theforeman.org/yaml/jobs/plugins/foreman_templates.yaml
@@ -1,5 +1,0 @@
-- project:
-    name: foreman_templates
-    defaults: plugin
-    jobs:
-      - 'test_plugin_{name}_{branch}'


### PR DESCRIPTION
These have migrated to GitHub Actions.

This doesn't take care of:
* foreman_setup (to be archived: https://community.theforeman.org/t/retire-foreman-setup-plugin/36594)
* foreman_default_hostgroup (https://github.com/theforeman/foreman_default_hostgroup/pull/62 is still in progress)
* foreman & katello (they're different, this is just the templated job)