### PR TITLE
inject foreman version for stable plugin builds

### DIFF
--- a/theforeman.org/pipelines/lib/packaging.groovy
+++ b/theforeman.org/pipelines/lib/packaging.groovy
@@ -405,6 +405,7 @@ def setup_sources_plugin(project, os, version, repoowner, pull_request = false) 
             last_commit = git_hash()
             add_automated_debian_changelog('plugins', package_version, repoowner, last_commit)
         }
+        inject_foreman_release_version(version)
     }
 
     return "${build_dir}/${package_dir}"
@@ -433,6 +434,13 @@ def inject_debian_release_version(os) {
     ]
     def suffix="+${debian_release_to_version[os]}"
     sh(script: "sed -i '1 s/)/${suffix})/' debian/changelog", label: "inject Debian release into package version")
+}
+
+def inject_foreman_release_version(version) {
+    if (version != 'nightly') {
+        def suffix="~fm${version}"
+        sh(script: "sed -i '1 s/)/${suffix})/' debian/changelog", label: "inject Foreman release into package version")
+    }
 }
 
 def execute_pbuilder(build_dir, os, version) {


### PR DESCRIPTION
this allows to have the same plugin version to have different builds for different foreman releases, thus making it possible to cleanly upgrade to plugin builds that match the foreman release even if there are no plugin version differences.

practical example: foreman_puppet 6.2.0 exists in 3.8, 3.9, 3.10 and nightly, but in 3.10 and nightly it needs to be built with Webpack5 and not 3 to work.
before this change, all builds ended up being 6.2.0-1 and apt would not consider to upgrade those when coming from 3.9 to 3.10, creating a broken setup.
with this change, the versions would be:
`6.2.0-1~fm3.8`
`6.2.0-1~fm3.9`
`6.2.0-1~fm3.10`
`6.2.0-1`
which apt will gladly upgrade in that order

It would be cool if we could name the last one 6.2.0-1~3.11, but there is no way for us to know that the next version will be 3.11 at that point