### PR TITLE
enable upgrade pipelines for katello on el9

### DIFF
--- a/theforeman.org/pipelines/vars/katello/nightly.groovy
+++ b/theforeman.org/pipelines/vars/katello/nightly.groovy
@@ -14,6 +14,8 @@ def pipelines = [
     ],
     'upgrade': [
         'centos8-stream',
+        'centos9-stream',
         'almalinux8',
+        'almalinux9',
     ]
 ]


### PR DESCRIPTION
draft because:
- [x] needs Foreman 3.10-rc1 and Katello 4.12-rc1 to be published
- [x] needs python3.11-solv to be fixed on EL9 to be upgradeable (see https://github.com/theforeman/pulpcore-packaging/pull/938)
- [x] https://github.com/theforeman/forklift/pull/1815