### PR TITLE
test nightly on Debian 12

### DIFF
--- a/theforeman.org/pipelines/vars/foreman/nightly.groovy
+++ b/theforeman.org/pipelines/vars/foreman/nightly.groovy
@@ -15,6 +15,7 @@ def foreman_debian_releases = ['bullseye', 'bookworm', 'jammy']
 def pipelines_deb = [
     'install': [
         'debian11',
+        'debian12',
         'ubuntu2204'
     ],
     'upgrade': [


### PR DESCRIPTION
Currently this fails because there is no `puppetserver` on apt.puppet.com and our installer doesn't cope well with the non-AIO version in Debian