### PR TITLE
Rely on theforeman-rel-eng projects to upload staging

### DIFF
--- a/theforeman.org/pipelines/lib/packaging.groovy
+++ b/theforeman.org/pipelines/lib/packaging.groovy
@@ -481,22 +481,19 @@ def rsync_debian(user, ssh_key, suite, component, deb_paths) {
     }
 }
 
-def rsync_to_yum_stage(collection, target, version) {
-    def user = 'yumrepostage'
-    def ssh_key = '/home/jenkins/workspace/staging_key/rsync_yumrepostage_key'
-
-    rsync_yum(user, ssh_key, collection, target, version)
+// Scripts that wrap https://github.com/theforeman/theforeman-rel-eng
+def rel_eng_clone() {
+    git url: "https://github.com/theforeman/theforeman-rel-eng", poll: false
 }
 
-def rsync_yum(user, ssh_key, collection, target, version) {
-    def hosts = ["web01.osuosl.theforeman.org"]
+def rel_eng_build_stage() {
+    script {
+        sh "./generate_stage_repository"
+    }
+}
 
-    for(host in hosts) {
-        def target_path = "${user}@${host}:rsync_cache/${target}/${version}/"
-
-        sh """
-            export RSYNC_RSH="ssh -i ${ssh_key}"
-            /usr/bin/rsync --checksum --times --perms --recursive --links --verbose --partial --one-file-system --delete-after ${collection}/${version}/ ${target_path}
-        """
+def rel_eng_upload_stage() {
+    script {
+        sh "./upload_stage_rpms"
     }
 }

--- a/theforeman.org/pipelines/release/pipelines/candlepin.groovy
+++ b/theforeman.org/pipelines/release/pipelines/candlepin.groovy
@@ -13,26 +13,15 @@ pipeline {
             when {
                 expression { candlepin_version == 'nightly' }
             }
-            steps {
-                git url: "https://github.com/theforeman/theforeman-rel-eng", poll: false
-
-                script {
-                    candlepin_distros.each { distro ->
-                        sh "./build_stage_repository candlepin ${candlepin_version} ${distro}"
-                    }
-                }
-            }
-        }
-        stage('staging-copy-repository') {
-            when {
-                expression { candlepin_version == 'nightly' }
+            environment {
+                PROJECT = 'candlepin'
+                VERSION = candlepin_version
+                RSYNC_RSH = "ssh -i ${ssh_key}"
             }
             steps {
-                script {
-                    dir('tmp') {
-                        rsync_to_yum_stage('candlepin', 'candlepin', candlepin_version)
-                    }
-                }
+                rel_eng_clone()
+                rel_eng_build_stage()
+                rel_eng_upload_stage()
             }
         }
         stage('staging-repoclosure') {

--- a/theforeman.org/pipelines/release/pipelines/client.groovy
+++ b/theforeman.org/pipelines/release/pipelines/client.groovy
@@ -16,26 +16,15 @@ pipeline {
                     when {
                         expression { foreman_version == 'nightly' }
                     }
-                    steps {
-                        git url: "https://github.com/theforeman/theforeman-rel-eng", poll: false
-
-                        script {
-                            foreman_client_distros.each { distro ->
-                                sh "./build_stage_repository client ${foreman_version} ${distro}"
-                            }
-                        }
-                    }
-                }
-                stage('staging-copy-repository') {
-                    when {
-                        expression { foreman_version == 'nightly' }
+                    environment {
+                        PROJECT = 'client'
+                        VERSION = foreman_version
+                        RSYNC_RSH = "ssh -i ${ssh_key}"
                     }
                     steps {
-                        script {
-                            dir('tmp') {
-                                rsync_to_yum_stage('client', 'client', foreman_version)
-                            }
-                        }
+                        rel_eng_clone()
+                        rel_eng_build_stage()
+                        rel_eng_upload_stage()
                     }
                 }
                 stage('staging-repoclosure') {

--- a/theforeman.org/pipelines/release/pipelines/foreman-rpm.groovy
+++ b/theforeman.org/pipelines/release/pipelines/foreman-rpm.groovy
@@ -16,26 +16,15 @@ pipeline {
                     when {
                         expression { foreman_version == 'nightly' }
                     }
-                    steps {
-                        git url: "https://github.com/theforeman/theforeman-rel-eng", poll: false
-
-                        script {
-                            foreman_el_releases.each { distro ->
-                                sh "./build_stage_repository foreman ${foreman_version} ${distro}"
-                            }
-                        }
-                    }
-                }
-                stage('staging-copy-repository') {
-                    when {
-                        expression { foreman_version == 'nightly' }
+                    environment {
+                        PROJECT = 'foreman'
+                        VERSION = foreman_version
+                        RSYNC_RSH = "ssh -i ${ssh_key}"
                     }
                     steps {
-                        script {
-                            dir('tmp') {
-                                rsync_to_yum_stage('foreman', 'foreman', foreman_version)
-                            }
-                        }
+                        rel_eng_clone()
+                        rel_eng_build_stage()
+                        rel_eng_upload_stage()
                     }
                 }
                 stage('staging-repoclosure') {

--- a/theforeman.org/pipelines/release/pipelines/katello.groovy
+++ b/theforeman.org/pipelines/release/pipelines/katello.groovy
@@ -16,26 +16,15 @@ pipeline {
                     when {
                         expression { katello_version == 'nightly' }
                     }
-                    steps {
-                        git url: "https://github.com/theforeman/theforeman-rel-eng", poll: false
-
-                        script {
-                            foreman_el_releases.each { distro ->
-                                sh "./build_stage_repository katello ${katello_version} ${distro} ${foreman_version}"
-                            }
-                        }
-                    }
-                }
-                stage('staging-copy-repository') {
-                    when {
-                        expression { katello_version == 'nightly' }
+                    environment {
+                        PROJECT = 'katello'
+                        VERSION = katello_version
+                        RSYNC_RSH = "ssh -i ${ssh_key}"
                     }
                     steps {
-                        script {
-                            dir('tmp') {
-                                rsync_to_yum_stage('katello', 'katello', katello_version)
-                            }
-                        }
+                        rel_eng_clone()
+                        rel_eng_build_stage()
+                        rel_eng_upload_stage()
                     }
                 }
                 stage('staging-repoclosure') {

--- a/theforeman.org/pipelines/release/pipelines/plugins.groovy
+++ b/theforeman.org/pipelines/release/pipelines/plugins.groovy
@@ -13,23 +13,15 @@ pipeline {
             agent { label 'el8' }
             stages {
                 stage('staging-build-repository') {
-                    steps {
-                        git url: "https://github.com/theforeman/theforeman-rel-eng", poll: false
-
-                        script {
-                            foreman_el_releases.each { distro ->
-                                sh "./build_stage_repository plugins ${foreman_version} ${distro}"
-                            }
-                        }
+                    environment {
+                        PROJECT = 'plugins'
+                        VERSION = foreman_version
+                        RSYNC_RSH = "ssh -i ${ssh_key}"
                     }
-                }
-                stage('staging-copy-repository') {
                     steps {
-                        script {
-                            dir('tmp') {
-                                rsync_to_yum_stage('plugins', 'plugins', foreman_version)
-                            }
-                        }
+                        rel_eng_clone()
+                        rel_eng_build_stage()
+                        rel_eng_upload_stage()
                     }
                 }
                 stage('staging-repoclosure') {

--- a/theforeman.org/pipelines/release/pipelines/pulpcore.groovy
+++ b/theforeman.org/pipelines/release/pipelines/pulpcore.groovy
@@ -17,26 +17,15 @@ pipeline {
                     when {
                         expression { pulpcore_version == 'nightly' }
                     }
-                    steps {
-                        git url: "https://github.com/theforeman/theforeman-rel-eng", poll: false
-
-                        script {
-                            pulpcore_distros.each { distro ->
-                                sh "./build_stage_repository pulpcore ${pulpcore_version} ${distro}"
-                            }
-                        }
-                    }
-                }
-                stage('staging-copy-repository') {
-                    when {
-                        expression { pulpcore_version == 'nightly' }
+                    environment {
+                        PROJECT = 'pulpcore'
+                        VERSION = pulpcore_version
+                        RSYNC_RSH = "ssh -i ${ssh_key}"
                     }
                     steps {
-                        script {
-                            dir('tmp') {
-                                rsync_to_yum_stage('pulpcore', 'pulpcore', pulpcore_version)
-                            }
-                        }
+                        rel_eng_clone()
+                        rel_eng_build_stage()
+                        rel_eng_upload_stage()
                     }
                 }
                 stage('staging-repoclosure') {


### PR DESCRIPTION
This introduces simple wrappers around theforeman-rel-eng scripts to do the heavy lifting. The biggest benefit is that more configuration is removed from this repository and pushed into theforeman-rel-eng where it was already anyway.

It is an alternative to https://github.com/theforeman/jenkins-jobs/pull/369. The biggest difference is using environment variables via native Jenkins to separate out the logic and keep method invocations easier. Right now it collapses two stages into a single stage since they both share the same configuration.

I'll reference this in my review of https://github.com/theforeman/jenkins-jobs/pull/369.