### PR TITLE
Drop Koji leftover in nightly release jobs

### DIFF
--- a/theforeman.org/pipelines/release/foreman-x-develop-release.groovy
+++ b/theforeman.org/pipelines/release/foreman-x-develop-release.groovy
@@ -52,7 +52,6 @@ pipeline {
                                             action: 'nightly',
                                             packages: rpm_source_package_name,
                                             extraVars: [
-                                                'releasers': releasers,
                                                 'nightly_sourcefiles': artifact_path,
                                                 'nightly_githash': commit_hash,
                                                 'build_package_build_system': 'copr',


### PR DESCRIPTION
The releasers need to be set when tito is used to release, but tito no longer used by us.

Fixes: 8d73ce80678c ("Drop koji related code")