### PR TITLE
switch duffy provisioning to CentOS Stream 9 boxes

### DIFF
--- a/centos.org/ansible/provision_duffy.yml
+++ b/centos.org/ansible/provision_duffy.yml
@@ -3,7 +3,7 @@
   tasks:
     - name: 'Get a new node'
       evgeni.duffy.session_request:
-        pool: metal-ec2-c5n-centos-8s-x86_64
+        pool: metal-ec2-c5n-centos-9s-x86_64
         quantity: 1
       register: duffy_data
 


### PR DESCRIPTION
I've only tested that vagrant is installable so far, but with CS8 going EOL soon, we should rather switch and fix up any possible fallout