### PR TITLE
Test using rbenv for foreman-installer tests

### DIFF
--- a/theforeman.org/pipelines/lib/rbenv.groovy
+++ b/theforeman.org/pipelines/lib/rbenv.groovy
@@ -1,0 +1,30 @@
+def bundleInstall(version, gemfile=null) {
+    command = "bundle install"
+
+    if (gemfile) {
+        command = "${command} --gemfile=${gemfile}"
+    }
+
+    withRuby(version, "bundle config set path ~/.rubygems")
+    withRuby(version, command)
+}
+
+def bundleExec(version, command, gemfile=null) {
+    command = "bundle exec ${command}"
+
+    if (gemfile) {
+        command = "BUNDLE_GEMFILE=${gemfile} ${command}"
+    }
+
+    withRuby(version, command)
+}
+
+def withRuby(version, command) {
+    echo command.toString()
+
+    sh """
+        export PATH="\$HOME/.rbenv/shims:\$PATH"
+        export RBENV_VERSION=${version}
+        ${command}
+    """
+}

--- a/theforeman.org/pipelines/test/simple-ruby.groovy
+++ b/theforeman.org/pipelines/test/simple-ruby.groovy
@@ -1,0 +1,38 @@
+def ruby = '2.7.6'
+
+pipeline {
+    agent { label 'el8' }
+    options {
+        timeout(time: 1, unit: 'HOURS')
+        ansiColor('xterm')
+    }
+
+    stages {
+        stage('Setup Git Repos') {
+            steps {
+                git url: 'https://github.com/theforeman/foreman-installer', branch: 'develop'
+                sh "cp Gemfile Gemfile.${ruby}"
+            }
+        }
+        stage("bundle-install") {
+            steps {
+                bundleInstall(ruby, "Gemfile.${ruby}")
+            }
+        }
+        stage('Run Rubocop') {
+            steps {
+                bundleExec(ruby, "rake rubocop TESTOPTS='-v' --trace", "Gemfile.${ruby}")
+            }
+        }
+        stage('Run Tests') {
+            steps {
+                bundleExec(ruby, "rake spec TESTOPTS='-v' --trace", "Gemfile.${ruby}")
+            }
+        }
+    }
+    post {
+        always {
+            deleteDir()
+        }
+    }
+}

--- a/theforeman.org/yaml/jobs/simple.yaml
+++ b/theforeman.org/yaml/jobs/simple.yaml
@@ -1,0 +1,8 @@
+- job:
+    name: simple-ruby-test
+    project-type: pipeline
+    sandbox: true
+    dsl:
+      !include-raw:
+        - pipelines/lib/rbenv.groovy
+        - pipelines/test/simple-ruby.groovy

--- a/theforeman.org/yaml/jobs/tests/foreman-installer-pr-test.yaml
+++ b/theforeman.org/yaml/jobs/tests/foreman-installer-pr-test.yaml
@@ -13,4 +13,5 @@
       !include-raw:
         - pipelines/lib/git.groovy
         - pipelines/lib/rvm.groovy
+        - pipelines/lib/rbenv.groovy
         - pipelines/test/foreman-installer.groovy


### PR DESCRIPTION
There are a couple implications here:

 1. Using a node wide cache for rubygems to speed bundle install up
 2. Using shell based rbenv to prevent clashes between instances