### PR TITLE
enable upgrade tests for Ubuntu 22.04

### DIFF
--- a/theforeman.org/pipelines/vars/foreman/nightly.groovy
+++ b/theforeman.org/pipelines/vars/foreman/nightly.groovy
@@ -20,7 +20,8 @@ def pipelines_deb = [
     ],
     'upgrade': [
         'debian11',
-        'ubuntu2004'
+        'ubuntu2004',
+        'ubuntu2204'
     ]
 ]
 


### PR DESCRIPTION
now that 3.11 is RC and we have a upgrade base
