### PR TITLE
Drop centos8-stream support from pipelines

### DIFF
--- a/theforeman.org/pipelines/vars/candlepin/4.3.groovy
+++ b/theforeman.org/pipelines/vars/candlepin/4.3.groovy
@@ -3,7 +3,8 @@ def candlepin_distros = ['el8', 'el9']
 def packaging_branch = 'rpm/4.3'
 def pipelines = [
     'candlepin': [
-        'centos8-stream',
-        'centos9-stream'
+        'centos9-stream',
+        'almalinux8',
+        'almalinux9',
     ]
 ]

--- a/theforeman.org/pipelines/vars/candlepin/4.4.groovy
+++ b/theforeman.org/pipelines/vars/candlepin/4.4.groovy
@@ -3,7 +3,8 @@ def candlepin_distros = ['el8', 'el9']
 def packaging_branch = 'rpm/4.4'
 def pipelines = [
     'candlepin': [
-        'centos8-stream',
-        'centos9-stream'
+        'centos9-stream',
+        'almalinux8',
+        'almalinux9',
     ]
 ]

--- a/theforeman.org/pipelines/vars/candlepin/nightly.groovy
+++ b/theforeman.org/pipelines/vars/candlepin/nightly.groovy
@@ -6,7 +6,8 @@ def candlepin_distros = [
 ]
 def pipelines = [
     'candlepin': [
-        'centos8-stream',
-        'centos9-stream'
+        'centos9-stream',
+        'almalinux8',
+        'almalinux9',
     ]
 ]

--- a/theforeman.org/pipelines/vars/foreman/3.10.groovy
+++ b/theforeman.org/pipelines/vars/foreman/3.10.groovy
@@ -25,13 +25,11 @@ def pipelines_deb = [
 
 def pipelines_el = [
     'install': [
-        'centos8-stream',
         'centos9-stream',
         'almalinux8',
         'almalinux9',
     ],
     'upgrade': [
-        'centos8-stream',
         'almalinux8',
     ]
 ]

--- a/theforeman.org/pipelines/vars/foreman/3.11.groovy
+++ b/theforeman.org/pipelines/vars/foreman/3.11.groovy
@@ -26,13 +26,11 @@ def pipelines_deb = [
 
 def pipelines_el = [
     'install': [
-        'centos8-stream',
         'centos9-stream',
         'almalinux8',
         'almalinux9',
     ],
     'upgrade': [
-        'centos8-stream',
         'centos9-stream',
         'almalinux8',
         'almalinux9',

--- a/theforeman.org/pipelines/vars/foreman/3.9.groovy
+++ b/theforeman.org/pipelines/vars/foreman/3.9.groovy
@@ -24,11 +24,9 @@ def pipelines_deb = [
 
 def pipelines_el = [
     'install': [
-        'centos8-stream',
         'almalinux8',
     ],
     'upgrade': [
-        'centos8-stream',
         'almalinux8',
     ]
 ]

--- a/theforeman.org/pipelines/vars/foreman/nightly.groovy
+++ b/theforeman.org/pipelines/vars/foreman/nightly.groovy
@@ -27,13 +27,11 @@ def pipelines_deb = [
 
 def pipelines_el = [
     'install': [
-        'centos8-stream',
         'centos9-stream',
         'almalinux8',
         'almalinux9',
     ],
     'upgrade': [
-        'centos8-stream',
         'centos9-stream',
         'almalinux8',
         'almalinux9',

--- a/theforeman.org/pipelines/vars/katello/4.11.groovy
+++ b/theforeman.org/pipelines/vars/katello/4.11.groovy
@@ -5,11 +5,9 @@ def foreman_el_releases = [
 ]
 def pipelines = [
     'install': [
-        'centos8-stream',
         'almalinux8',
     ],
     'upgrade': [
-        'centos8-stream',
         'almalinux8',
     ]
 ]

--- a/theforeman.org/pipelines/vars/katello/4.12.groovy
+++ b/theforeman.org/pipelines/vars/katello/4.12.groovy
@@ -6,13 +6,11 @@ def foreman_el_releases = [
 ]
 def pipelines = [
     'install': [
-        'centos8-stream',
         'centos9-stream',
         'almalinux8',
         'almalinux9',
     ],
     'upgrade': [
-        'centos8-stream',
         'almalinux8',
     ]
 ]

--- a/theforeman.org/pipelines/vars/katello/4.13.groovy
+++ b/theforeman.org/pipelines/vars/katello/4.13.groovy
@@ -6,13 +6,11 @@ def foreman_el_releases = [
 ]
 def pipelines = [
     'install': [
-        'centos8-stream',
         'centos9-stream',
         'almalinux8',
         'almalinux9',
     ],
     'upgrade': [
-        'centos8-stream',
         'centos9-stream',
         'almalinux8',
         'almalinux9',

--- a/theforeman.org/pipelines/vars/katello/nightly.groovy
+++ b/theforeman.org/pipelines/vars/katello/nightly.groovy
@@ -6,13 +6,11 @@ def foreman_el_releases = [
 ]
 def pipelines = [
     'install': [
-        'centos8-stream',
         'centos9-stream',
         'almalinux8',
         'almalinux9',
     ],
     'upgrade': [
-        'centos8-stream',
         'centos9-stream',
         'almalinux8',
         'almalinux9',

--- a/theforeman.org/pipelines/vars/pulpcore/3.39.groovy
+++ b/theforeman.org/pipelines/vars/pulpcore/3.39.groovy
@@ -3,7 +3,8 @@ def pulpcore_distros = ['el8', 'el9']
 def packaging_branch = 'rpm/3.39'
 def pipelines = [
     'pulpcore': [
-        'centos8-stream',
-        'centos9-stream'
+        'centos9-stream',
+        'almalinux8',
+        'almalinux9',
     ]
 ]

--- a/theforeman.org/pipelines/vars/pulpcore/3.49.groovy
+++ b/theforeman.org/pipelines/vars/pulpcore/3.49.groovy
@@ -3,7 +3,8 @@ def pulpcore_distros = ['el8', 'el9']
 def packaging_branch = 'rpm/3.49'
 def pipelines = [
     'pulpcore': [
-        'centos8-stream',
-        'centos9-stream'
+        'centos9-stream',
+        'almalinux8',
+        'almalinux9',
     ]
 ]

--- a/theforeman.org/pipelines/vars/pulpcore/nightly.groovy
+++ b/theforeman.org/pipelines/vars/pulpcore/nightly.groovy
@@ -3,7 +3,8 @@ def pulpcore_distros = ['el8', 'el9']
 def packaging_branch = 'rpm/develop'
 def pipelines = [
     'pulpcore': [
-        'centos8-stream',
-        'centos9-stream'
+        'centos9-stream',
+        'almalinux8',
+        'almalinux9',
     ]
 ]


### PR DESCRIPTION
Updated pipeline configuration in [theforeman.org/pipelines/vars/katello/](https://github.com/theforeman/jenkins-jobs/tree/master/theforeman.org/pipelines/vars/katello) and [theforeman.org/pipelines/vars/foreman/](https://github.com/theforeman/jenkins-jobs/tree/master/theforeman.org/pipelines/vars/foreman) to drop support for `centos8-stream` due to CentOS 8 EOL

Dropped centos8-stream support and added AlmaLinux support for candlepin in theforeman.org/pipelines/vars/candlepin and pulpcore in theforeman.org/pipelines/vars/pulpcore.