### PR TITLE
Drop CentOS 8 Stream support and add AlmaLinux support

### DIFF
--- a/theforeman.org/pipelines/vars/candlepin/4.3.groovy
+++ b/theforeman.org/pipelines/vars/candlepin/4.3.groovy
@@ -3,7 +3,7 @@ def candlepin_distros = ['el8', 'el9']
 def packaging_branch = 'rpm/4.3'
 def pipelines = [
     'candlepin': [
-        'centos8-stream',
-        'centos9-stream'
+        'centos9-stream',
+        'almalinux8'
     ]
 ]

--- a/theforeman.org/pipelines/vars/candlepin/4.4.groovy
+++ b/theforeman.org/pipelines/vars/candlepin/4.4.groovy
@@ -3,7 +3,7 @@ def candlepin_distros = ['el8', 'el9']
 def packaging_branch = 'rpm/4.4'
 def pipelines = [
     'candlepin': [
-        'centos8-stream',
-        'centos9-stream'
+        'centos9-stream',
+        'almalinux8',
     ]
 ]

--- a/theforeman.org/pipelines/vars/candlepin/nightly.groovy
+++ b/theforeman.org/pipelines/vars/candlepin/nightly.groovy
@@ -6,7 +6,7 @@ def candlepin_distros = [
 ]
 def pipelines = [
     'candlepin': [
-        'centos8-stream',
-        'centos9-stream'
+        'centos9-stream',
+        'almalinux8',
     ]
 ]

--- a/theforeman.org/pipelines/vars/pulpcore/3.39.groovy
+++ b/theforeman.org/pipelines/vars/pulpcore/3.39.groovy
@@ -3,7 +3,7 @@ def pulpcore_distros = ['el8', 'el9']
 def packaging_branch = 'rpm/3.39'
 def pipelines = [
     'pulpcore': [
-        'centos8-stream',
-        'centos9-stream'
+        'centos9-stream',
+        'almalinux8',
     ]
 ]

--- a/theforeman.org/pipelines/vars/pulpcore/3.49.groovy
+++ b/theforeman.org/pipelines/vars/pulpcore/3.49.groovy
@@ -3,7 +3,7 @@ def pulpcore_distros = ['el8', 'el9']
 def packaging_branch = 'rpm/3.49'
 def pipelines = [
     'pulpcore': [
-        'centos8-stream',
-        'centos9-stream'
+        'centos9-stream',
+        'almalinux8',
     ]
 ]

--- a/theforeman.org/pipelines/vars/pulpcore/nightly.groovy
+++ b/theforeman.org/pipelines/vars/pulpcore/nightly.groovy
@@ -3,7 +3,7 @@ def pulpcore_distros = ['el8', 'el9']
 def packaging_branch = 'rpm/develop'
 def pipelines = [
     'pulpcore': [
-        'centos8-stream',
-        'centos9-stream'
+        'centos9-stream',
+        'almalinux8',
     ]
 ]


### PR DESCRIPTION
Updated pipeline configurations to drop CentOS 8 Stream support and add AlmaLinux support for candlepin in [theforeman.org/pipelines/vars/candlepin ](https://github.com/theforeman/jenkins-jobs/tree/master/theforeman.org/pipelines/vars/candlepin)and pulpcore in [theforeman.org/pipelines/vars/pulpcore](https://github.com/theforeman/jenkins-jobs/tree/master/theforeman.org/pipelines/vars/pulpcore).