### PR TITLE
Align pipelines on repoclosures() function

### DIFF
--- a/theforeman.org/pipelines/release/pipelines/client.groovy
+++ b/theforeman.org/pipelines/release/pipelines/client.groovy
@@ -36,16 +36,7 @@ pipeline {
         stage('staging-repoclosure') {
             steps {
                 script {
-                    def parallelStagesMap = [:]
-                    def name = 'foreman-client-staging'
-                    foreman_client_distros.each { distro ->
-                        if (distro.startsWith('el')) {
-                            parallelStagesMap[distro] = { repoclosure(name, distro, foreman_version) }
-                        } else if (distro.startsWith('fc')) {
-                            parallelStagesMap[distro] = { repoclosure(name, distro.replace('fc', 'f'), foreman_version) }
-                        }
-                    }
-                    parallel parallelStagesMap
+                    parallel repoclosures('foreman-client-staging', foreman_client_distros, foreman_version)
                 }
             }
             post {

--- a/theforeman.org/pipelines/release/pipelines/katello.groovy
+++ b/theforeman.org/pipelines/release/pipelines/katello.groovy
@@ -36,12 +36,7 @@ pipeline {
         stage('staging-repoclosure') {
             steps {
                 script {
-                    def parallelStagesMap = [:]
-                    def name = 'katello-staging'
-                    foreman_el_releases.each { distro ->
-                        parallelStagesMap[distro] = { repoclosure(name, distro, foreman_version) }
-                    }
-                    parallel parallelStagesMap
+                    parallel repoclosures('katello-staging', foreman_el_releases, foreman_version)
                 }
             }
             post {

--- a/theforeman.org/pipelines/release/pipelines/plugins.groovy
+++ b/theforeman.org/pipelines/release/pipelines/plugins.groovy
@@ -30,12 +30,7 @@ pipeline {
         stage('staging-repoclosure') {
             steps {
                 script {
-                    def parallelStagesMap = [:]
-                    def name = 'plugins-staging'
-                    foreman_el_releases.each { distro ->
-                        parallelStagesMap[distro] = { repoclosure(name, distro, foreman_version) }
-                    }
-                    parallel parallelStagesMap
+                    parallel repoclosures('plugins-staging', foreman_el_releases, foreman_version)
                 }
             }
             post {

--- a/theforeman.org/pipelines/release/pipelines/pulpcore.groovy
+++ b/theforeman.org/pipelines/release/pipelines/pulpcore.groovy
@@ -36,12 +36,7 @@ pipeline {
         stage('staging-repoclosure') {
             steps {
                 script {
-                    def parallelStagesMap = [:]
-                    def name = 'pulpcore-staging'
-                    pulpcore_distros.each { distro ->
-                        parallelStagesMap[distro] = { repoclosure(name, distro, pulpcore_version) }
-                    }
-                    parallel parallelStagesMap
+                    parallel repoclosures('pulpcore-staging', foreman_el_releases, foreman_version)
                 }
             }
             post {


### PR DESCRIPTION
For client it still had Fedora compatiblity code, but that has been dropped in Foreman 3.1 so no longer relevant.

Split off from https://github.com/theforeman/jenkins-jobs/pull/458.