### PR TITLE
rename hammer-cli-katello jobs to "main"

### DIFF
--- a/theforeman.org/yaml/jobs/release/package/hammer-cli-katello-main-package-release.yaml
+++ b/theforeman.org/yaml/jobs/release/package/hammer-cli-katello-main-package-release.yaml
@@ -1,19 +1,19 @@
 - job:
-    name: hammer-cli-katello-master-source-release
+    name: hammer-cli-katello-main-package-release
     project-type: pipeline
     sandbox: true
     concurrent: false
-    quiet-period: 600
     properties:
       - github:
           url: 'https://github.com/Katello/hammer-cli-katello'
-    triggers:
-      - github
     dsl:
       !include-raw-verbatim:
         - pipelines/vars/hammer-cli-katello-master.groovy
-        - pipelines/release/source/hammer-cli-x.groovy
-        - pipelines/lib/nightly_packaging.groovy
+        - pipelines/release/foreman-x-develop-release.groovy
         - pipelines/lib/foreman_infra.groovy
         - pipelines/lib/rbenv.groovy
+        - pipelines/lib/obal.groovy
         - pipelines/lib/git.groovy
+        - pipelines/lib/ansible.groovy
+        - pipelines/lib/nightly_packaging.groovy
+        - pipelines/lib/packaging.groovy

--- a/theforeman.org/yaml/jobs/release/source/hammer-cli-katello-main-source-release.yaml
+++ b/theforeman.org/yaml/jobs/release/source/hammer-cli-katello-main-source-release.yaml
@@ -1,19 +1,19 @@
 - job:
-    name: hammer-cli-katello-master-package-release
+    name: hammer-cli-katello-main-source-release
     project-type: pipeline
     sandbox: true
     concurrent: false
+    quiet-period: 600
     properties:
       - github:
           url: 'https://github.com/Katello/hammer-cli-katello'
+    triggers:
+      - github
     dsl:
       !include-raw-verbatim:
         - pipelines/vars/hammer-cli-katello-master.groovy
-        - pipelines/release/foreman-x-develop-release.groovy
+        - pipelines/release/source/hammer-cli-x.groovy
+        - pipelines/lib/nightly_packaging.groovy
         - pipelines/lib/foreman_infra.groovy
         - pipelines/lib/rbenv.groovy
-        - pipelines/lib/obal.groovy
         - pipelines/lib/git.groovy
-        - pipelines/lib/ansible.groovy
-        - pipelines/lib/nightly_packaging.groovy
-        - pipelines/lib/packaging.groovy


### PR DESCRIPTION
otherwise the triggers don't fire properly
