### PR TITLE
Run source release jobs at least once a day to update dependencies

### DIFF
--- a/theforeman.org/yaml/jobs/release/source/foreman-develop-source-release.yaml
+++ b/theforeman.org/yaml/jobs/release/source/foreman-develop-source-release.yaml
@@ -8,6 +8,7 @@
     concurrent: false
     triggers:
       - github
+      - timed: '@daily'
     dsl:
       !include-raw-verbatim:
         - pipelines/vars/foreman-develop-release.groovy

--- a/theforeman.org/yaml/jobs/release/source/hammer-cli-foreman-master-source-release.yaml
+++ b/theforeman.org/yaml/jobs/release/source/hammer-cli-foreman-master-source-release.yaml
@@ -9,6 +9,7 @@
           url: 'https://github.com/theforeman/hammer-cli-foreman'
     triggers:
       - github
+      - timed: '@daily'
     dsl:
       !include-raw-verbatim:
         - pipelines/vars/hammer-cli-foreman-master.groovy

--- a/theforeman.org/yaml/jobs/release/source/hammer-cli-katello-main-source-release.yaml
+++ b/theforeman.org/yaml/jobs/release/source/hammer-cli-katello-main-source-release.yaml
@@ -9,6 +9,7 @@
           url: 'https://github.com/Katello/hammer-cli-katello'
     triggers:
       - github
+      - timed: '@daily'
     dsl:
       !include-raw-verbatim:
         - pipelines/vars/hammer-cli-katello-master.groovy

--- a/theforeman.org/yaml/jobs/release/source/hammer-cli-master-source-release.yaml
+++ b/theforeman.org/yaml/jobs/release/source/hammer-cli-master-source-release.yaml
@@ -9,6 +9,7 @@
           url: 'https://github.com/theforeman/hammer-cli'
     triggers:
       - github
+      - timed: '@daily'
     dsl:
       !include-raw-verbatim:
         - pipelines/vars/hammer-cli-master.groovy

--- a/theforeman.org/yaml/jobs/release/source/katello-master-source-release.yaml
+++ b/theforeman.org/yaml/jobs/release/source/katello-master-source-release.yaml
@@ -8,6 +8,7 @@
           url: https://github.com/Katello/katello
     triggers:
       - github
+      - timed: '@daily'
     dsl:
       !include-raw-verbatim:
         - pipelines/vars/katello-master-release.groovy

--- a/theforeman.org/yaml/jobs/release/source/smart-proxy-develop-source-release.yaml
+++ b/theforeman.org/yaml/jobs/release/source/smart-proxy-develop-source-release.yaml
@@ -9,6 +9,7 @@
           url: https://github.com/theforeman/smart-proxy
     triggers:
       - github
+      - timed: '@daily'
     dsl:
       !include-raw-verbatim:
         - pipelines/vars/smart-proxy-develop-release.groovy


### PR DESCRIPTION
Some of our projects do not receive merges regularly and therefore their source release jobs do not trigger. The source release jobs are the basis for how we determine packaging updates for dependencies. Let's run these at least once a day to pick up any dependency updates to keep packaging up to date.

Recent example: https://ci.theforeman.org/job/smart-proxy-develop-source-release/

This had not run since August 21st, and therefore packaging has not picked up the webrick 1.8.2 security release.