### PR TITLE
enable upgrade tests for Debian 12

### DIFF
--- a/theforeman.org/pipelines/vars/foreman/nightly.groovy
+++ b/theforeman.org/pipelines/vars/foreman/nightly.groovy
@@ -20,6 +20,7 @@ def pipelines_deb = [
     ],
     'upgrade': [
         'debian11',
+        'debian12',
         'ubuntu2204'
     ]
 ]


### PR DESCRIPTION
we actually have packages for 3.11 and 3.12, so we can test nightly
upgrades too
