### PR TITLE
run Katello rubocop without Foreman checkout

### DIFF
--- a/theforeman.org/pipelines/release/source/katello.groovy
+++ b/theforeman.org/pipelines/release/source/katello.groovy
@@ -60,9 +60,8 @@ pipeline {
                 }
                 stage('rubocop') {
                     steps {
-                        dir('foreman') {
-                            bundleExec(ruby, 'rake katello:rubocop TESTOPTS="-v" --trace')
-                        }
+                        bundleInstall(ruby)
+                        bundleExec(ruby, 'rubocop --parallel')
                     }
                 }
                 stage('react-ui') {


### PR DESCRIPTION
Foreman limits the rubocop version, so we we end up using the one
defined by Foreman, not by Katello, but Katello's rubocop_todo is not
compatible with that.
