### PR TITLE
disable Almalinux for nightly until 9.5 is out

### DIFF
--- a/theforeman.org/pipelines/vars/foreman/nightly.groovy
+++ b/theforeman.org/pipelines/vars/foreman/nightly.groovy
@@ -27,11 +27,9 @@ def pipelines_deb = [
 def pipelines_el = [
     'install': [
         'centos9-stream',
-        'almalinux9',
     ],
     'upgrade': [
         'centos9-stream',
-        'almalinux9',
     ]
 ]
 

--- a/theforeman.org/pipelines/vars/katello/nightly.groovy
+++ b/theforeman.org/pipelines/vars/katello/nightly.groovy
@@ -6,10 +6,8 @@ def foreman_el_releases = [
 def pipelines = [
     'install': [
         'centos9-stream',
-        'almalinux9',
     ],
     'upgrade': [
         'centos9-stream',
-        'almalinux9',
     ]
 ]


### PR DESCRIPTION
We build our packages on RHEL (right now 9.5), which sometimes makes
them uninstallable on older releases. AlmaLinux 9.5 isn't out yet, and
our selinux policy fails to install on 9.4 right now.

Disable it for the time being, to be reverted when AL9.5 is out.
