### PR TITLE
Use rpm context for packaging PRs

### DIFF
--- a/theforeman.org/yaml/jobs/packaging/foreman-packaging-rpm-pr-test.yaml
+++ b/theforeman.org/yaml/jobs/packaging/foreman-packaging-rpm-pr-test.yaml
@@ -8,7 +8,7 @@
       - github:
           url: https://github.com/theforeman/foreman-packaging
     triggers:
-      - github_pr_rpm_copr_foreman:
+      - github_pr_rpm:
           context: 'rpm-copr'
     dsl:
       !include-raw-verbatim:

--- a/theforeman.org/yaml/jobs/packaging/foreman-packaging-rpm-pr-test.yaml
+++ b/theforeman.org/yaml/jobs/packaging/foreman-packaging-rpm-pr-test.yaml
@@ -9,7 +9,7 @@
           url: https://github.com/theforeman/foreman-packaging
     triggers:
       - github_pr_rpm:
-          context: 'rpm-copr'
+          context: 'rpm'
     dsl:
       !include-raw-verbatim:
         - pipelines/test/rpm_copr_packaging.groovy

--- a/theforeman.org/yaml/jobs/packaging/pulpcore-packaging-rpm-pr-test.yaml
+++ b/theforeman.org/yaml/jobs/packaging/pulpcore-packaging-rpm-pr-test.yaml
@@ -9,7 +9,7 @@
           url: https://github.com/theforeman/pulpcore-packaging
     triggers:
       - github_pr_rpm:
-          context: 'rpm-copr'
+          context: 'rpm'
     dsl:
       !include-raw-verbatim:
         - pipelines/test/rpm_copr_packaging.groovy

--- a/theforeman.org/yaml/jobs/packaging/pulpcore-packaging-rpm-pr-test.yaml
+++ b/theforeman.org/yaml/jobs/packaging/pulpcore-packaging-rpm-pr-test.yaml
@@ -8,7 +8,7 @@
       - github:
           url: https://github.com/theforeman/pulpcore-packaging
     triggers:
-      - github_pr_rpm_copr_pulpcore:
+      - github_pr_rpm:
           context: 'rpm-copr'
     dsl:
       !include-raw-verbatim:

--- a/theforeman.org/yaml/triggers/github_pr.yaml
+++ b/theforeman.org/yaml/triggers/github_pr.yaml
@@ -33,16 +33,7 @@
             - deb/.*
 
 - trigger:
-    name: github_pr_rpm_copr_foreman
-    triggers:
-      - github-pull-request:
-          <<: *ghprb_defaults
-          status-url: https://ci.theforeman.org/blue/organizations/jenkins/$JOB_NAME/detail/$JOB_NAME/$BUILD_ID/pipeline
-          white-list-target-branches:
-            - rpm/.*
-
-- trigger:
-    name: github_pr_rpm_copr_pulpcore
+    name: github_pr_rpm
     triggers:
       - github-pull-request:
           <<: *ghprb_defaults


### PR DESCRIPTION
This uses the context rpm again instead of rpm-copr. Now that koji is gone, there's no more need for this distinction.