### PR TITLE
Drop Debian 11 bullseye in nightly

### DIFF
--- a/theforeman.org/pipelines/lib/packaging.groovy
+++ b/theforeman.org/pipelines/lib/packaging.groovy
@@ -71,7 +71,7 @@ def find_changed_debs(diff_range) {
             type: 'plugin',
             name: project,
             path: "${folder}/${project}",
-            operating_system: 'bullseye'
+            operating_system: 'jammy'
         ])
     }
 

--- a/theforeman.org/pipelines/vars/foreman/nightly.groovy
+++ b/theforeman.org/pipelines/vars/foreman/nightly.groovy
@@ -10,16 +10,14 @@ def foreman_client_distros = [
 def foreman_el_releases = [
     'el9'
 ]
-def foreman_debian_releases = ['bullseye', 'bookworm', 'jammy']
+def foreman_debian_releases = ['bookworm', 'jammy']
 
 def pipelines_deb = [
     'install': [
-        'debian11',
         'debian12',
         'ubuntu2204'
     ],
     'upgrade': [
-        'debian11',
         'debian12',
         'ubuntu2204'
     ]


### PR DESCRIPTION
This replaces plugin building from bullseye to jammy because that's the now the oldest release we support.