### PR TITLE
Fix instance of git_checkout

### DIFF
--- a/theforeman.org/pipelines/test/smart-proxy.groovy
+++ b/theforeman.org/pipelines/test/smart-proxy.groovy
@@ -61,9 +61,7 @@ pipeline {
                 stages {
                     stage('Setup Git Repos') {
                         steps {
-                            script {
-                                git_checkout()
-                            }
+                            git branch: git_branch, url: 'https://github.com/theforeman/smart-proxy'
                         }
                     }
                     stage('Install dependencies') {


### PR DESCRIPTION
In 70d9a4525b5b36e7644d817db04c554882485b54 the git_checkout function was removed but this remained.

Fixes: 70d9a4525b5b ("drop smart-proxy-pr-test and all non-packaging PR testing remains")