### PR TITLE
Align the develop and stable testing jobs

### DIFF
--- a/theforeman.org/pipelines/release/foreman-x-develop-release.groovy
+++ b/theforeman.org/pipelines/release/foreman-x-develop-release.groovy
@@ -17,6 +17,10 @@ pipeline {
         buildDiscarder(logRotator(daysToKeepStr: '7'))
     }
 
+    triggers {
+        upstream(upstreamProjects: source_project_name, threshold: hudson.model.Result.SUCCESS)
+    }
+
     stages {
         stage('Build Package') {
             parallel {

--- a/theforeman.org/pipelines/release/source/foreman-installer.groovy
+++ b/theforeman.org/pipelines/release/source/foreman-installer.groovy
@@ -34,14 +34,6 @@ pipeline {
         }
     }
     post {
-        success {
-            build(
-                job: "${project_name}-${git_ref}-package-release",
-                propagate: false,
-                wait: false
-            )
-        }
-
         failure {
             notifyDiscourse(env, "${project_name} source release pipeline failed:", currentBuild.description)
         }

--- a/theforeman.org/pipelines/release/source/foreman-selinux.groovy
+++ b/theforeman.org/pipelines/release/source/foreman-selinux.groovy
@@ -37,14 +37,6 @@ pipeline {
         }
     }
     post {
-        success {
-            build(
-                job: "${project_name}-${git_ref}-package-release",
-                propagate: false,
-                wait: false
-            )
-        }
-
         failure {
             notifyDiscourse(env, "${project_name} source release pipeline failed:", currentBuild.description)
         }

--- a/theforeman.org/pipelines/release/source/foreman.groovy
+++ b/theforeman.org/pipelines/release/source/foreman.groovy
@@ -96,15 +96,6 @@ pipeline {
     }
 
     post {
-        success {
-            build(
-                job: "${project_name}-${git_ref}-package-release",
-                propagate: false,
-                wait: false
-            )
-
-        }
-
         failure {
             notifyDiscourse(env, "${project_name} source release pipeline failed:", currentBuild.description)
         }

--- a/theforeman.org/pipelines/release/source/hammer-cli-x.groovy
+++ b/theforeman.org/pipelines/release/source/hammer-cli-x.groovy
@@ -35,14 +35,6 @@ pipeline {
         }
     }
     post {
-        success {
-            build(
-                job: "${project_name}-${git_ref}-package-release",
-                propagate: false,
-                wait: false
-            )
-        }
-
         failure {
             notifyDiscourse(env, "${project_name} source release pipeline failed:", currentBuild.description)
         }

--- a/theforeman.org/pipelines/release/source/katello.groovy
+++ b/theforeman.org/pipelines/release/source/katello.groovy
@@ -135,14 +135,6 @@ pipeline {
     }
 
     post {
-        success {
-            build(
-                job: "${project_name}-${git_ref}-package-release",
-                propagate: false,
-                wait: false
-            )
-        }
-
         failure {
             notifyDiscourse(env, "${project_name} source release pipeline failed:", currentBuild.description)
         }

--- a/theforeman.org/pipelines/release/source/smart-proxy.groovy
+++ b/theforeman.org/pipelines/release/source/smart-proxy.groovy
@@ -1,9 +1,9 @@
 pipeline {
-    agent any
+    agent none
 
     options {
         timestamps()
-        timeout(time: 2, unit: 'HOURS')
+        timeout(time: 1, unit: 'HOURS')
         ansiColor('xterm')
         buildDiscarder(logRotator(daysToKeepStr: '7'))
     }
@@ -18,13 +18,22 @@ pipeline {
                         values '2.7.6', '3.0.4', '3.1.0'
                     }
                 }
+                environment {
+                    BUNDLE_WITHOUT = 'development'
+                }
                 stages {
                     stage("Clone repository") {
                         steps {
                             git url: git_url, branch: git_ref
                         }
                     }
-                    stage("Test Ruby") {
+                    stage('Install dependencies') {
+                        steps {
+                            bundleInstall(ruby)
+                            archiveArtifacts(artifacts: 'Gemfile.lock')
+                        }
+                    }
+                    stage('Run tests') {
                         environment {
                             // ci_reporters gem
                             CI_REPORTS = 'jenkins/reports/unit'
@@ -33,7 +42,12 @@ pipeline {
                             MINITEST_REPORTERS_REPORTS_DIR = 'jenkins/reports/unit'
                         }
                         steps {
-                            run_test(ruby: env.ruby)
+                            bundleExec(ruby, 'rake jenkins:unit')
+                        }
+                        post {
+                            always {
+                                junit testResults: 'jenkins/reports/unit/*.xml'
+                            }
                         }
                     }
                 }
@@ -45,6 +59,8 @@ pipeline {
             }
         }
         stage('Build and Archive Source') {
+            agent any
+
             steps {
                 dir(project_name) {
                     git url: git_url, branch: git_ref
@@ -58,6 +74,11 @@ pipeline {
                     sourcefile_paths = generate_sourcefiles(project_name: project_name, source_type: source_type)
                 }
             }
+            post {
+                always {
+                    deleteDir()
+                }
+            }
         }
     }
 
@@ -65,22 +86,5 @@ pipeline {
         failure {
             notifyDiscourse(env, "${project_name} source release pipeline failed:", currentBuild.description)
         }
-
-        cleanup {
-            deleteDir()
-        }
-    }
-}
-
-def run_test(args) {
-    def ruby = args.ruby
-
-    try {
-        sh "cp config/settings.yml.example config/settings.yml"
-        bundleInstall(ruby, "--without=development")
-        archiveArtifacts(artifacts: 'Gemfile.lock')
-        bundleExec(ruby, "rake jenkins:unit --trace")
-    } finally {
-        junit(testResults: 'jenkins/reports/unit/*.xml')
     }
 }

--- a/theforeman.org/pipelines/release/source/smart-proxy.groovy
+++ b/theforeman.org/pipelines/release/source/smart-proxy.groovy
@@ -62,14 +62,6 @@ pipeline {
     }
 
     post {
-        success {
-            build(
-                job: "${project_name}-${git_ref}-package-release",
-                propagate: false,
-                wait: false
-            )
-        }
-
         failure {
             notifyDiscourse(env, "${project_name} source release pipeline failed:", currentBuild.description)
         }

--- a/theforeman.org/pipelines/test/smart-proxy.groovy
+++ b/theforeman.org/pipelines/test/smart-proxy.groovy
@@ -1,12 +1,9 @@
 pipeline {
     agent none
+
     options {
         timeout(time: 1, unit: 'HOURS')
         ansiColor('xterm')
-    }
-    environment {
-        BUNDLE_JOBS = 4
-        BUNDLE_RETRY = 3
     }
 
     stages {
@@ -59,7 +56,7 @@ pipeline {
                     BUNDLE_WITHOUT = 'development'
                 }
                 stages {
-                    stage('Setup Git Repos') {
+                    stage("Clone repository") {
                         steps {
                             git branch: git_branch, url: 'https://github.com/theforeman/smart-proxy'
                         }
@@ -67,9 +64,10 @@ pipeline {
                     stage('Install dependencies') {
                         steps {
                             bundleInstall(ruby)
+                            archiveArtifacts(artifacts: 'Gemfile.lock')
                         }
                     }
-                    stage('Run Tests') {
+                    stage('Run tests') {
                         environment {
                             // ci_reporters gem
                             CI_REPORTS = 'jenkins/reports/unit'
@@ -89,7 +87,6 @@ pipeline {
                 }
                 post {
                     always {
-                        archiveArtifacts artifacts: 'Gemfile.lock'
                         deleteDir()
                     }
                 }


### PR DESCRIPTION
This is a bit of an experiment to see if we can use the same jobs for testing develop and stable branches. It's inspired by https://github.com/theforeman/jenkins-jobs/pull/525.

Some differences we should discuss:
* It still runs RuboCop on develop, but should we? it's not something we care about
* It only builds the package for develop, but perhaps we can just build it for all
* Build rotation: can we align on a week of builds and X builds? Not sure
* Shall we drop the matrix building and align on a single Ruby version per release? Do we pick the oldest version?