### PR TITLE
correctly cleanup smart-proxy release tests

### DIFF
--- a/theforeman.org/pipelines/release/source/smart-proxy.groovy
+++ b/theforeman.org/pipelines/release/source/smart-proxy.groovy
@@ -37,6 +37,11 @@ pipeline {
                         }
                     }
                 }
+                post {
+                    always {
+                        deleteDir()
+                    }
+                }
             }
         }
         stage('Build and Archive Source') {


### PR DESCRIPTION
they happen in a matrix, so deleteDir needs to be called for all
parallel directories
