### PR TITLE
Don't migrate databases when using NullDB

### DIFF
--- a/theforeman.org/pipelines/test/foreman.groovy
+++ b/theforeman.org/pipelines/test/foreman.groovy
@@ -47,6 +47,9 @@ pipeline {
                         }
                     }
                     stage('database') {
+                        when {
+                            expression { RAKE_TASK != 'assets:precompile' }
+                        }
                         steps {
                             bundleExec(RUBY_VERSION, "rake db:create --trace")
                             bundleExec(RUBY_VERSION, "rake db:migrate --trace")


### PR DESCRIPTION
We don't do this on GitHub for plugins either:
- https://github.com/theforeman/actions/blob/bdcb752893a2d63958b49f323a8ace3b2ceb7728/.github/workflows/foreman_plugin.yml#L166-L170

And for Foreman core it is run with PostgreSQL, not NullDB:
- https://github.com/theforeman/foreman/blob/f8e1a2711a24fa7cf337a9d0376d088d9e0410a7/.github/workflows/foreman.yml#L12-L13
- https://github.com/theforeman/foreman/blob/f8e1a2711a24fa7cf337a9d0376d088d9e0410a7/.github/workflows/foreman.yml#L121-L124

Copying an empty `schema.rb`, which we do, should be sufficient for
NullDB and assets.

Fixes: e5cb2b04a6b539697b0c9a8211b892251cbbfd9c
