### PR TITLE
Revert "Set trigger package release jobs instead of on source jobs"

### DIFF
--- a/theforeman.org/pipelines/release/foreman-x-develop-release.groovy
+++ b/theforeman.org/pipelines/release/foreman-x-develop-release.groovy
@@ -17,10 +17,6 @@ pipeline {
         buildDiscarder(logRotator(daysToKeepStr: '7'))
     }
 
-    triggers {
-        upstream(upstreamProjects: source_project_name, threshold: hudson.model.Result.SUCCESS)
-    }
-
     stages {
         stage('Build Package') {
             parallel {

--- a/theforeman.org/pipelines/release/source/foreman-installer.groovy
+++ b/theforeman.org/pipelines/release/source/foreman-installer.groovy
@@ -34,6 +34,14 @@ pipeline {
         }
     }
     post {
+        success {
+            build(
+                job: "${project_name}-${git_ref}-package-release",
+                propagate: false,
+                wait: false
+            )
+        }
+
         failure {
             notifyDiscourse(env, "${project_name} source release pipeline failed:", currentBuild.description)
         }

--- a/theforeman.org/pipelines/release/source/foreman-selinux.groovy
+++ b/theforeman.org/pipelines/release/source/foreman-selinux.groovy
@@ -37,6 +37,14 @@ pipeline {
         }
     }
     post {
+        success {
+            build(
+                job: "${project_name}-${git_ref}-package-release",
+                propagate: false,
+                wait: false
+            )
+        }
+
         failure {
             notifyDiscourse(env, "${project_name} source release pipeline failed:", currentBuild.description)
         }

--- a/theforeman.org/pipelines/release/source/foreman.groovy
+++ b/theforeman.org/pipelines/release/source/foreman.groovy
@@ -96,6 +96,15 @@ pipeline {
     }
 
     post {
+        success {
+            build(
+                job: "${project_name}-${git_ref}-package-release",
+                propagate: false,
+                wait: false
+            )
+
+        }
+
         failure {
             notifyDiscourse(env, "${project_name} source release pipeline failed:", currentBuild.description)
         }

--- a/theforeman.org/pipelines/release/source/hammer-cli-x.groovy
+++ b/theforeman.org/pipelines/release/source/hammer-cli-x.groovy
@@ -35,6 +35,14 @@ pipeline {
         }
     }
     post {
+        success {
+            build(
+                job: "${project_name}-${git_ref}-package-release",
+                propagate: false,
+                wait: false
+            )
+        }
+
         failure {
             notifyDiscourse(env, "${project_name} source release pipeline failed:", currentBuild.description)
         }

--- a/theforeman.org/pipelines/release/source/katello.groovy
+++ b/theforeman.org/pipelines/release/source/katello.groovy
@@ -135,6 +135,14 @@ pipeline {
     }
 
     post {
+        success {
+            build(
+                job: "${project_name}-${git_ref}-package-release",
+                propagate: false,
+                wait: false
+            )
+        }
+
         failure {
             notifyDiscourse(env, "${project_name} source release pipeline failed:", currentBuild.description)
         }

--- a/theforeman.org/pipelines/release/source/smart-proxy.groovy
+++ b/theforeman.org/pipelines/release/source/smart-proxy.groovy
@@ -83,6 +83,14 @@ pipeline {
     }
 
     post {
+        success {
+            build(
+                job: "${project_name}-${git_ref}-package-release",
+                propagate: false,
+                wait: false
+            )
+        }
+
         failure {
             notifyDiscourse(env, "${project_name} source release pipeline failed:", currentBuild.description)
         }


### PR DESCRIPTION
multiple package release jobs aren't triggering at the moment. Reverting this commit to get those jobs back on track.

This reverts commit f790d4cf1a88bf513d262db5608497665368ef00.