### PR TITLE
Remove AlmaLinux 9 testing

### DIFF
--- a/theforeman.org/pipelines/vars/candlepin/4.4.groovy
+++ b/theforeman.org/pipelines/vars/candlepin/4.4.groovy
@@ -5,6 +5,5 @@ def pipelines = [
     'candlepin': [
         'centos9-stream',
         'almalinux8',
-        'almalinux9',
     ]
 ]

--- a/theforeman.org/pipelines/vars/candlepin/4.6.groovy
+++ b/theforeman.org/pipelines/vars/candlepin/4.6.groovy
@@ -6,6 +6,5 @@ def candlepin_distros = [
 def pipelines = [
     'candlepin': [
         'centos9-stream',
-        'almalinux9',
     ]
 ]

--- a/theforeman.org/pipelines/vars/candlepin/nightly.groovy
+++ b/theforeman.org/pipelines/vars/candlepin/nightly.groovy
@@ -6,6 +6,5 @@ def candlepin_distros = [
 def pipelines = [
     'candlepin': [
         'centos9-stream',
-        'almalinux9',
     ]
 ]

--- a/theforeman.org/pipelines/vars/foreman/3.15.groovy
+++ b/theforeman.org/pipelines/vars/foreman/3.15.groovy
@@ -26,11 +26,9 @@ def pipelines_deb = [
 def pipelines_el = [
     'install': [
         'centos9-stream',
-        'almalinux9',
     ],
     'upgrade': [
         'centos9-stream',
-        'almalinux9',
     ]
 ]
 

--- a/theforeman.org/pipelines/vars/foreman/3.16.groovy
+++ b/theforeman.org/pipelines/vars/foreman/3.16.groovy
@@ -26,11 +26,9 @@ def pipelines_deb = [
 def pipelines_el = [
     'install': [
         'centos9-stream',
-        'almalinux9',
     ],
     'upgrade': [
         'centos9-stream',
-        'almalinux9',
     ]
 ]
 

--- a/theforeman.org/pipelines/vars/foreman/3.17.groovy
+++ b/theforeman.org/pipelines/vars/foreman/3.17.groovy
@@ -26,11 +26,9 @@ def pipelines_deb = [
 def pipelines_el = [
     'install': [
         'centos9-stream',
-        'almalinux9',
     ],
     'upgrade': [
         'centos9-stream',
-        'almalinux9',
     ]
 ]
 

--- a/theforeman.org/pipelines/vars/foreman/nightly.groovy
+++ b/theforeman.org/pipelines/vars/foreman/nightly.groovy
@@ -26,11 +26,9 @@ def pipelines_deb = [
 def pipelines_el = [
     'install': [
         'centos9-stream',
-        'almalinux9',
     ],
     'upgrade': [
         'centos9-stream',
-        'almalinux9',
     ]
 ]
 

--- a/theforeman.org/pipelines/vars/katello/4.17.groovy
+++ b/theforeman.org/pipelines/vars/katello/4.17.groovy
@@ -6,10 +6,8 @@ def foreman_el_releases = [
 def pipelines = [
     'install': [
         'centos9-stream',
-        'almalinux9',
     ],
     'upgrade': [
         'centos9-stream',
-        'almalinux9',
     ]
 ]

--- a/theforeman.org/pipelines/vars/katello/4.18.groovy
+++ b/theforeman.org/pipelines/vars/katello/4.18.groovy
@@ -6,10 +6,8 @@ def foreman_el_releases = [
 def pipelines = [
     'install': [
         'centos9-stream',
-        'almalinux9',
     ],
     'upgrade': [
         'centos9-stream',
-        'almalinux9',
     ]
 ]

--- a/theforeman.org/pipelines/vars/katello/4.19.groovy
+++ b/theforeman.org/pipelines/vars/katello/4.19.groovy
@@ -6,10 +6,8 @@ def foreman_el_releases = [
 def pipelines = [
     'install': [
         'centos9-stream',
-        'almalinux9',
     ],
     'upgrade': [
         'centos9-stream',
-        'almalinux9',
     ]
 ]

--- a/theforeman.org/pipelines/vars/katello/nightly.groovy
+++ b/theforeman.org/pipelines/vars/katello/nightly.groovy
@@ -6,10 +6,8 @@ def foreman_el_releases = [
 def pipelines = [
     'install': [
         'centos9-stream',
-        'almalinux9',
     ],
     'upgrade': [
         'centos9-stream',
-        'almalinux9',
     ]
 ]

--- a/theforeman.org/pipelines/vars/pulpcore/3.63.groovy
+++ b/theforeman.org/pipelines/vars/pulpcore/3.63.groovy
@@ -4,6 +4,5 @@ def packaging_branch = 'rpm/3.63'
 def pipelines = [
     'pulpcore': [
         'centos9-stream',
-        'almalinux9',
     ]
 ]

--- a/theforeman.org/pipelines/vars/pulpcore/3.73.groovy
+++ b/theforeman.org/pipelines/vars/pulpcore/3.73.groovy
@@ -4,6 +4,5 @@ def packaging_branch = 'rpm/3.73'
 def pipelines = [
     'pulpcore': [
         'centos9-stream',
-        'almalinux9',
     ]
 ]

--- a/theforeman.org/pipelines/vars/pulpcore/3.85.groovy
+++ b/theforeman.org/pipelines/vars/pulpcore/3.85.groovy
@@ -4,6 +4,5 @@ def packaging_branch = 'rpm/3.85'
 def pipelines = [
     'pulpcore': [
         'centos9-stream',
-        'almalinux9',
     ]
 ]

--- a/theforeman.org/pipelines/vars/pulpcore/nightly.groovy
+++ b/theforeman.org/pipelines/vars/pulpcore/nightly.groovy
@@ -4,6 +4,5 @@ def packaging_branch = 'rpm/develop'
 def pipelines = [
     'pulpcore': [
         'centos9-stream',
-        'almalinux9',
     ]
 ]


### PR DESCRIPTION
AlmaLinux is a bit behind with 9.7 release, which is causing us installation failures. Let's skip testing it until they release 9.7.

