### PR TITLE
Remove AlmaLinux 9 testing

### DIFF
--- a/theforeman.org/pipelines/vars/candlepin/4.6.groovy
+++ b/theforeman.org/pipelines/vars/candlepin/4.6.groovy
@@ -6,6 +6,5 @@ def candlepin_distros = [
 def pipelines = [
     'candlepin': [
         'centos9-stream',
-        'almalinux9',
     ]
 ]

--- a/theforeman.org/pipelines/vars/candlepin/4.7.groovy
+++ b/theforeman.org/pipelines/vars/candlepin/4.7.groovy
@@ -6,6 +6,5 @@ def candlepin_distros = [
 def pipelines = [
     'candlepin': [
         'centos9-stream',
-        'almalinux9',
     ]
 ]

--- a/theforeman.org/pipelines/vars/candlepin/nightly.groovy
+++ b/theforeman.org/pipelines/vars/candlepin/nightly.groovy
@@ -6,6 +6,5 @@ def candlepin_distros = [
 def pipelines = [
     'candlepin': [
         'centos9-stream',
-        'almalinux9',
     ]
 ]

--- a/theforeman.org/pipelines/vars/foreman/3.17.groovy
+++ b/theforeman.org/pipelines/vars/foreman/3.17.groovy
@@ -26,11 +26,9 @@ def pipelines_deb = [
 def pipelines_el = [
     'install': [
         'centos9-stream',
-        'almalinux9',
     ],
     'upgrade': [
         'centos9-stream',
-        'almalinux9',
     ]
 ]
 

--- a/theforeman.org/pipelines/vars/foreman/3.18.groovy
+++ b/theforeman.org/pipelines/vars/foreman/3.18.groovy
@@ -26,11 +26,9 @@ def pipelines_deb = [
 def pipelines_el = [
     'install': [
         'centos9-stream',
-        'almalinux9',
     ],
     'upgrade': [
         'centos9-stream',
-        'almalinux9',
     ]
 ]
 

--- a/theforeman.org/pipelines/vars/foreman/3.19.groovy
+++ b/theforeman.org/pipelines/vars/foreman/3.19.groovy
@@ -26,11 +26,9 @@ def pipelines_deb = [
 def pipelines_el = [
     'install': [
         'centos9-stream',
-        'almalinux9',
     ],
     'upgrade': [
         'centos9-stream',
-        'almalinux9',
     ]
 ]
 

--- a/theforeman.org/pipelines/vars/foreman/nightly.groovy
+++ b/theforeman.org/pipelines/vars/foreman/nightly.groovy
@@ -26,11 +26,9 @@ def pipelines_deb = [
 def pipelines_el = [
     'install': [
         'centos9-stream',
-        'almalinux9',
     ],
     'upgrade': [
         'centos9-stream',
-        'almalinux9',
     ]
 ]
 

--- a/theforeman.org/pipelines/vars/katello/4.19.groovy
+++ b/theforeman.org/pipelines/vars/katello/4.19.groovy
@@ -6,10 +6,8 @@ def foreman_el_releases = [
 def pipelines = [
     'install': [
         'centos9-stream',
-        'almalinux9',
     ],
     'upgrade': [
         'centos9-stream',
-        'almalinux9',
     ]
 ]

--- a/theforeman.org/pipelines/vars/katello/4.20.groovy
+++ b/theforeman.org/pipelines/vars/katello/4.20.groovy
@@ -6,10 +6,8 @@ def foreman_el_releases = [
 def pipelines = [
     'install': [
         'centos9-stream',
-        'almalinux9',
     ],
     'upgrade': [
         'centos9-stream',
-        'almalinux9',
     ]
 ]

--- a/theforeman.org/pipelines/vars/katello/4.21.groovy
+++ b/theforeman.org/pipelines/vars/katello/4.21.groovy
@@ -6,10 +6,8 @@ def foreman_el_releases = [
 def pipelines = [
     'install': [
         'centos9-stream',
-        'almalinux9',
     ],
     'upgrade': [
         'centos9-stream',
-        'almalinux9',
     ]
 ]

--- a/theforeman.org/pipelines/vars/katello/nightly.groovy
+++ b/theforeman.org/pipelines/vars/katello/nightly.groovy
@@ -6,10 +6,8 @@ def foreman_el_releases = [
 def pipelines = [
     'install': [
         'centos9-stream',
-        'almalinux9',
     ],
     'upgrade': [
         'centos9-stream',
-        'almalinux9',
     ]
 ]

--- a/theforeman.org/pipelines/vars/pulpcore/3.105.groovy
+++ b/theforeman.org/pipelines/vars/pulpcore/3.105.groovy
@@ -4,6 +4,5 @@ def packaging_branch = 'rpm/3.105'
 def pipelines = [
     'pulpcore': [
         'centos9-stream',
-        'almalinux9',
     ]
 ]

--- a/theforeman.org/pipelines/vars/pulpcore/3.63.groovy
+++ b/theforeman.org/pipelines/vars/pulpcore/3.63.groovy
@@ -4,6 +4,5 @@ def packaging_branch = 'rpm/3.63'
 def pipelines = [
     'pulpcore': [
         'centos9-stream',
-        'almalinux9',
     ]
 ]

--- a/theforeman.org/pipelines/vars/pulpcore/3.73.groovy
+++ b/theforeman.org/pipelines/vars/pulpcore/3.73.groovy
@@ -4,6 +4,5 @@ def packaging_branch = 'rpm/3.73'
 def pipelines = [
     'pulpcore': [
         'centos9-stream',
-        'almalinux9',
     ]
 ]

--- a/theforeman.org/pipelines/vars/pulpcore/3.85.groovy
+++ b/theforeman.org/pipelines/vars/pulpcore/3.85.groovy
@@ -4,6 +4,5 @@ def packaging_branch = 'rpm/3.85'
 def pipelines = [
     'pulpcore': [
         'centos9-stream',
-        'almalinux9',
     ]
 ]

--- a/theforeman.org/pipelines/vars/pulpcore/nightly.groovy
+++ b/theforeman.org/pipelines/vars/pulpcore/nightly.groovy
@@ -4,6 +4,5 @@ def packaging_branch = 'rpm/develop'
 def pipelines = [
     'pulpcore': [
         'centos9-stream',
-        'almalinux9',
     ]
 ]


### PR DESCRIPTION
AlmaLinux 9 is behind with the 9.8 release, causing installation failures due to missing `selinux-policy >= 38.1.75-2.el9_8`:

```
Error: Problem: conflicting requests
  - nothing provides selinux-policy >= 38.1.75-2.el9_8 needed by foreman-selinux-5.0.0-0.1.develop.20260521112111git5482061.el9.noarch
```

Skip testing it until they release 9.8.