### PR TITLE
Revert "Remove AlmaLinux 9 testing"

### DIFF
--- a/theforeman.org/pipelines/vars/candlepin/4.6.groovy
+++ b/theforeman.org/pipelines/vars/candlepin/4.6.groovy
@@ -6,5 +6,6 @@ def candlepin_distros = [
 def pipelines = [
     'candlepin': [
         'centos9-stream',
+        'almalinux9',
     ]
 ]

--- a/theforeman.org/pipelines/vars/candlepin/4.7.groovy
+++ b/theforeman.org/pipelines/vars/candlepin/4.7.groovy
@@ -6,5 +6,6 @@ def candlepin_distros = [
 def pipelines = [
     'candlepin': [
         'centos9-stream',
+        'almalinux9',
     ]
 ]

--- a/theforeman.org/pipelines/vars/candlepin/nightly.groovy
+++ b/theforeman.org/pipelines/vars/candlepin/nightly.groovy
@@ -6,5 +6,6 @@ def candlepin_distros = [
 def pipelines = [
     'candlepin': [
         'centos9-stream',
+        'almalinux9',
     ]
 ]

--- a/theforeman.org/pipelines/vars/foreman/3.17.groovy
+++ b/theforeman.org/pipelines/vars/foreman/3.17.groovy
@@ -26,9 +26,11 @@ def pipelines_deb = [
 def pipelines_el = [
     'install': [
         'centos9-stream',
+        'almalinux9',
     ],
     'upgrade': [
         'centos9-stream',
+        'almalinux9',
     ]
 ]
 

--- a/theforeman.org/pipelines/vars/foreman/3.18.groovy
+++ b/theforeman.org/pipelines/vars/foreman/3.18.groovy
@@ -26,9 +26,11 @@ def pipelines_deb = [
 def pipelines_el = [
     'install': [
         'centos9-stream',
+        'almalinux9',
     ],
     'upgrade': [
         'centos9-stream',
+        'almalinux9',
     ]
 ]
 

--- a/theforeman.org/pipelines/vars/foreman/3.19.groovy
+++ b/theforeman.org/pipelines/vars/foreman/3.19.groovy
@@ -26,9 +26,11 @@ def pipelines_deb = [
 def pipelines_el = [
     'install': [
         'centos9-stream',
+        'almalinux9',
     ],
     'upgrade': [
         'centos9-stream',
+        'almalinux9',
     ]
 ]
 

--- a/theforeman.org/pipelines/vars/foreman/nightly.groovy
+++ b/theforeman.org/pipelines/vars/foreman/nightly.groovy
@@ -26,9 +26,11 @@ def pipelines_deb = [
 def pipelines_el = [
     'install': [
         'centos9-stream',
+        'almalinux9',
     ],
     'upgrade': [
         'centos9-stream',
+        'almalinux9',
     ]
 ]
 

--- a/theforeman.org/pipelines/vars/katello/4.19.groovy
+++ b/theforeman.org/pipelines/vars/katello/4.19.groovy
@@ -6,8 +6,10 @@ def foreman_el_releases = [
 def pipelines = [
     'install': [
         'centos9-stream',
+        'almalinux9',
     ],
     'upgrade': [
         'centos9-stream',
+        'almalinux9',
     ]
 ]

--- a/theforeman.org/pipelines/vars/katello/4.20.groovy
+++ b/theforeman.org/pipelines/vars/katello/4.20.groovy
@@ -6,8 +6,10 @@ def foreman_el_releases = [
 def pipelines = [
     'install': [
         'centos9-stream',
+        'almalinux9',
     ],
     'upgrade': [
         'centos9-stream',
+        'almalinux9',
     ]
 ]

--- a/theforeman.org/pipelines/vars/katello/4.21.groovy
+++ b/theforeman.org/pipelines/vars/katello/4.21.groovy
@@ -6,8 +6,10 @@ def foreman_el_releases = [
 def pipelines = [
     'install': [
         'centos9-stream',
+        'almalinux9',
     ],
     'upgrade': [
         'centos9-stream',
+        'almalinux9',
     ]
 ]

--- a/theforeman.org/pipelines/vars/katello/nightly.groovy
+++ b/theforeman.org/pipelines/vars/katello/nightly.groovy
@@ -6,8 +6,10 @@ def foreman_el_releases = [
 def pipelines = [
     'install': [
         'centos9-stream',
+        'almalinux9',
     ],
     'upgrade': [
         'centos9-stream',
+        'almalinux9',
     ]
 ]

--- a/theforeman.org/pipelines/vars/pulpcore/3.105.groovy
+++ b/theforeman.org/pipelines/vars/pulpcore/3.105.groovy
@@ -4,5 +4,6 @@ def packaging_branch = 'rpm/3.105'
 def pipelines = [
     'pulpcore': [
         'centos9-stream',
+        'almalinux9',
     ]
 ]

--- a/theforeman.org/pipelines/vars/pulpcore/3.63.groovy
+++ b/theforeman.org/pipelines/vars/pulpcore/3.63.groovy
@@ -4,5 +4,6 @@ def packaging_branch = 'rpm/3.63'
 def pipelines = [
     'pulpcore': [
         'centos9-stream',
+        'almalinux9',
     ]
 ]

--- a/theforeman.org/pipelines/vars/pulpcore/3.73.groovy
+++ b/theforeman.org/pipelines/vars/pulpcore/3.73.groovy
@@ -4,5 +4,6 @@ def packaging_branch = 'rpm/3.73'
 def pipelines = [
     'pulpcore': [
         'centos9-stream',
+        'almalinux9',
     ]
 ]

--- a/theforeman.org/pipelines/vars/pulpcore/3.85.groovy
+++ b/theforeman.org/pipelines/vars/pulpcore/3.85.groovy
@@ -4,5 +4,6 @@ def packaging_branch = 'rpm/3.85'
 def pipelines = [
     'pulpcore': [
         'centos9-stream',
+        'almalinux9',
     ]
 ]

--- a/theforeman.org/pipelines/vars/pulpcore/nightly.groovy
+++ b/theforeman.org/pipelines/vars/pulpcore/nightly.groovy
@@ -4,5 +4,6 @@ def packaging_branch = 'rpm/develop'
 def pipelines = [
     'pulpcore': [
         'centos9-stream',
+        'almalinux9',
     ]
 ]


### PR DESCRIPTION
Reverts theforeman/jenkins-jobs#575

Alma released 9.8 yesterday. Let's wait to merge until 2025-05-28 to allow the CDN cache to update.