### PR TITLE
Run katello rubocop from foreman bundle

### DIFF
--- a/theforeman.org/pipelines/release/source/katello.groovy
+++ b/theforeman.org/pipelines/release/source/katello.groovy
@@ -61,8 +61,9 @@ pipeline {
                 }
                 stage('rubocop') {
                     steps {
-                        bundleInstall(ruby)
-                        bundleExec(ruby, 'rubocop --parallel')
+                        dir('foreman') {
+                            bundleExec(ruby, "rubocop --parallel ../${project_name}")
+                        }
                     }
                 }
                 stage('react-ui') {


### PR DESCRIPTION
The rubocop stage was running a separate bundle install from the katello root directory, which resolved Rails 7.1 / Rack 3 since katello.gemspec has no Rails version constraint. This ran in parallel with the test stage using Foreman's bundle (Rails 7.0 / Rack 2), both sharing ~/.rubygems, causing VCR body_json matcher failures in the Pulp3 MultiCopyAllUnit tests.

Run rubocop from the foreman directory using the already-installed Foreman bundle, matching how GitHub CI runs katello tests.