### PR TITLE
Isolate katello rubocop bundle to fix Rack version conflicts

### DIFF
--- a/theforeman.org/pipelines/release/source/katello.groovy
+++ b/theforeman.org/pipelines/release/source/katello.groovy
@@ -64,9 +64,8 @@ pipeline {
                         BUNDLE_PATH = "${env.WORKSPACE}/.rubocop_bundle"
                     }
                     steps {
-                        dir('foreman') {
-                            bundleExec(ruby, "rubocop --parallel ../${project_name}")
-                        }
+                        bundleInstall(ruby)
+                        bundleExec(ruby, 'rubocop --parallel')
                     }
                 }
                 stage('react-ui') {

--- a/theforeman.org/pipelines/release/source/katello.groovy
+++ b/theforeman.org/pipelines/release/source/katello.groovy
@@ -60,6 +60,9 @@ pipeline {
                     }
                 }
                 stage('rubocop') {
+                    environment {
+                        BUNDLE_PATH = "${env.WORKSPACE}/.rubocop_bundle"
+                    }
                     steps {
                         dir('foreman') {
                             bundleExec(ruby, "rubocop --parallel ../${project_name}")


### PR DESCRIPTION
## Summary
- The rubocop stage ran a separate `bundleInstall` from the katello root, which resolved Rails 7.1 / Rack 3 (katello.gemspec has no Rails version constraint). This ran in parallel with the test stage using Foreman's bundle (Rails 7.0 / Rack 2), both sharing `~/.rubygems`, causing VCR body_json matcher failures in the Pulp3 MultiCopyAllUnit tests.
- Isolate katello's rubocop bundle via `BUNDLE_PATH` so it no longer conflicts with Foreman's parallel bundle at `~/.rubygems`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)