### PR TITLE
Archive Copr build info as Jenkins artifacts

### DIFF
--- a/theforeman.org/pipelines/lib/obal.groovy
+++ b/theforeman.org/pipelines/lib/obal.groovy
@@ -31,6 +31,12 @@ def obal(args) {
     }
 }
 
+def archive_copr_build_info() {
+    if (fileExists('copr_build_info')) {
+        archiveArtifacts artifacts: 'copr_build_info/**'
+    }
+}
+
 def setup_obal() {
     dir("${env.WORKSPACE}/obsah") {
         checkout(

--- a/theforeman.org/pipelines/test/rpm_copr_packaging.groovy
+++ b/theforeman.org/pipelines/test/rpm_copr_packaging.groovy
@@ -179,6 +179,7 @@ pipeline {
     post {
         always {
             status_copr_links(ghprbGhRepository.split('/')[1])
+            archive_copr_build_info()
         }
     }
 }


### PR DESCRIPTION
## Summary
- Add `archive_copr_build_info()` helper to `obal.groovy` that archives the `copr_build_info/` directory as Jenkins artifacts
- Call it in the `foreman-packaging-rpm-copr-pr-test` pipeline post block
- Enables PR-to-Copr-build traceability — build IDs and URLs are now accessible from Jenkins build artifacts

## Context
The `copr_build_info/` directory is already produced by obal when `build_package_archive_build_info` is enabled, and consumed by `status_copr_links()` for GitHub status notifications. This change additionally archives it so the data persists as a Jenkins artifact.

## Test plan
- [ ] Trigger a `foreman-packaging-rpm-copr-pr-test` build
- [ ] Verify `copr_build_info/<package>` files appear in Jenkins build artifacts
- [ ] Verify existing behavior (GitHub status notifications, repoclosure) is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)