### PR TITLE
Bump hammer-cli source release pipeline to Ruby 3.0

### DIFF
--- a/theforeman.org/pipelines/release/source/hammer-cli-x.groovy
+++ b/theforeman.org/pipelines/release/source/hammer-cli-x.groovy
@@ -18,9 +18,9 @@ pipeline {
                 add_hammer_cli_git_repos(hammer_cli_git_repos)
             }
         }
-        stage("test-ruby-2.7") {
+        stage("test-ruby-3.0") {
             steps {
-                run_test(ruby: '2.7.6')
+                run_test(ruby: '3.0.4')
             }
         }
         stage('Build and Archive Source') {


### PR DESCRIPTION
## Summary
- Bump Ruby from 2.7.6 to 3.0.4 in the hammer-cli source release pipeline (`hammer-cli-x.groovy`)
- Affects both `hammer-cli-master-source-release` and `hammer-cli-foreman-master-source-release` jobs which share this pipeline

## Problem
The test stage ran on Ruby 2.7.6, which activated the `gem "ffi", "<1.17" if RUBY_VERSION < '3.0'` guard in hammer-cli's Gemfile. This guard exists because ffi 1.17+ precompiled platform gems require Ruby >= 3.0 and RubyGems >= 3.3.22.

Under Ruby 2.7, the guard capped ffi at <1.17, producing a Gemfile.lock with ffi 1.16.3. This lockfile artifact is consumed by `foreman-packaging`'s `list_updatable_packages`, which then saw ffi 1.16.3 (hammer-cli) vs 1.17.4 (katello, hammer-cli-foreman) and marked `rubygem-ffi` as CONFLICT, blocking the automated version bump.

- CI run showing the conflict: https://github.com/theforeman/foreman-packaging/actions/runs/28577817035/job/84730608902

## Fix
Since hammer-cli is packaged for Ruby 3.0, the CI lockfile should be generated under Ruby 3.0.4 (available on Jenkins nodes via rbenv) to reflect the actual target environment.

## Test plan
- [ ] Verify `hammer-cli-master-source-release` job runs successfully with Ruby 3.0.4
- [ ] Verify archived Gemfile.lock contains ffi 1.17.4 (not 1.16.3)
- [ ] Verify `list_updatable_packages` no longer marks rubygem-ffi as CONFLICT