### PR TITLE
Retrigger Konflux nightly component rebuilds after katello nightly pipeline

### DIFF
--- a/theforeman.org/pipelines/lib/konflux.groovy
+++ b/theforeman.org/pipelines/lib/konflux.groovy
@@ -1,0 +1,43 @@
+def konflux_api_server = 'https://api.kflux-fedora-01.84db.p1.openshiftapps.com:6443'
+def konflux_namespace = 'theforeman-org-tenant'
+def konflux_oc_channel = 'stable'
+
+def retrigger_konflux_components(components) {
+    if (!components) {
+        return
+    }
+
+    def oc_dir = "${env.WORKSPACE}/bin"
+    def oc_bin = "${oc_dir}/oc"
+
+    sh(
+        label: 'download oc client',
+        script: """
+            mkdir -p ${oc_dir}
+            curl -fsSL --retry 3 https://mirror.openshift.com/pub/openshift-v4/clients/ocp/${konflux_oc_channel}/openshift-client-linux.tar.gz | tar -xz -C ${oc_dir} oc
+            chmod +x ${oc_bin}
+        """
+    )
+
+    try {
+        withCredentials([string(credentialsId: 'konflux-jenkins-trigger-token', variable: 'KONFLUX_TOKEN')]) {
+            sh(
+                label: 'oc login to konflux (token hidden)',
+                script: """
+                    set +x
+                    ${oc_bin} login --token=\$KONFLUX_TOKEN --server=${konflux_api_server}
+                    set -x
+                """
+            )
+        }
+
+        components.each { component ->
+            sh(
+                label: "trigger konflux rebuild: ${component}",
+                script: "${oc_bin} annotate component ${component} --overwrite --namespace ${konflux_namespace} build.appstudio.openshift.io/request=trigger-rebuild"
+            )
+        }
+    } finally {
+        sh(label: 'remove oc client', script: "rm -rf ${oc_dir}")
+    }
+}

--- a/theforeman.org/pipelines/lib/konflux.groovy
+++ b/theforeman.org/pipelines/lib/konflux.groovy
@@ -9,6 +9,7 @@ def retrigger_konflux_components(components) {
 
     def oc_dir = "${env.WORKSPACE}/bin"
     def oc_bin = "${oc_dir}/oc"
+    def kubeconfig = "${oc_dir}/kubeconfig"
 
     sh(
         label: 'download oc client',
@@ -19,25 +20,30 @@ def retrigger_konflux_components(components) {
         """
     )
 
-    try {
-        withCredentials([string(credentialsId: 'konflux-jenkins-trigger-token', variable: 'KONFLUX_TOKEN')]) {
-            sh(
-                label: 'oc login to konflux (token hidden)',
-                script: """
-                    set +x
-                    ${oc_bin} login --token=\$KONFLUX_TOKEN --server=${konflux_api_server}
-                    set -x
-                """
-            )
-        }
+    // Runs on fixed, non-ephemeral 'el' agents, so the kubeconfig is scoped to
+    // the workspace (wiped below) instead of the shared ~/.kube/config.
+    withEnv(["KUBECONFIG=${kubeconfig}"]) {
+        try {
+            withCredentials([string(credentialsId: 'konflux-jenkins-trigger-token', variable: 'KONFLUX_TOKEN')]) {
+                sh(
+                    label: 'oc login to konflux (token hidden)',
+                    script: """
+                        set +x
+                        ${oc_bin} login --token=\$KONFLUX_TOKEN --server=${konflux_api_server}
+                        set -x
+                    """
+                )
+            }
 
-        components.each { component ->
-            sh(
-                label: "trigger konflux rebuild: ${component}",
-                script: "${oc_bin} annotate component ${component} --overwrite --namespace ${konflux_namespace} build.appstudio.openshift.io/request=trigger-rebuild"
-            )
+            components.each { component ->
+                sh(
+                    label: "trigger konflux rebuild: ${component}",
+                    script: "${oc_bin} annotate component ${component} --overwrite --namespace ${konflux_namespace} build.appstudio.openshift.io/request=trigger-rebuild"
+                )
+            }
+        } finally {
+            sh(label: 'oc logout from konflux', script: "${oc_bin} logout || true")
+            sh(label: 'remove oc client and kubeconfig', script: "rm -rf ${oc_dir}")
         }
-    } finally {
-        sh(label: 'remove oc client', script: "rm -rf ${oc_dir}")
     }
 }

--- a/theforeman.org/pipelines/release/pipelines/katello.groovy
+++ b/theforeman.org/pipelines/release/pipelines/katello.groovy
@@ -65,6 +65,17 @@ pipeline {
                 }
             }
         }
+        stage('trigger-konflux-rebuild') {
+            when {
+                expression { binding.hasVariable('konflux_components') && konflux_components }
+            }
+
+            steps {
+                script {
+                    retrigger_konflux_components(konflux_components)
+                }
+            }
+        }
     }
     post {
         failure {

--- a/theforeman.org/pipelines/vars/katello/nightly.groovy
+++ b/theforeman.org/pipelines/vars/katello/nightly.groovy
@@ -1,5 +1,6 @@
 def foreman_version = 'nightly'
 def katello_version = 'nightly'
+def konflux_components = ['candlepin-develop', 'foreman-develop', 'foreman-proxy-develop', 'pulp-develop']
 def foreman_el_releases = [
     'el9'
 ]

--- a/theforeman.org/yaml/jobs/pipeline/katello-nightly-rpm-pipeline.yaml
+++ b/theforeman.org/yaml/jobs/pipeline/katello-nightly-rpm-pipeline.yaml
@@ -16,3 +16,4 @@
         - pipelines/lib/foreman_infra.groovy
         - pipelines/lib/packaging.groovy
         - pipelines/lib/obal.groovy
+        - pipelines/lib/konflux.groovy


### PR DESCRIPTION
## Summary
- Adds a `trigger-konflux-rebuild` stage to `katello-nightly-rpm-pipeline` (`pipelines/release/pipelines/katello.groovy`), right after `staging-push-rpms`, that retriggers Konflux rebuilds for the four nightly (develop) components (`candlepin-develop`, `foreman-develop`, `foreman-proxy-develop`, `pulp-develop`) by annotating their Component CRs (`build.appstudio.openshift.io/request: trigger-rebuild`), per the [Konflux API retrigger docs](https://konflux-ci.dev/docs/building/running/#retriggering-a-post-merge-build-from-your-main-branch-from-the-api).
- New `pipelines/lib/konflux.groovy` downloads the `oc` client at runtime (stable channel, removed after use), logs in with a masked `string` credential binding (`konflux-jenkins-trigger-token`, wrapping the login line in `set +x`/`set -x` so the token never hits the console log), then runs `oc annotate` for each component.
- Scoped to katello nightly only for now. The 3.19 variants and `foreman-mcp-server-develop` will be added separately once this is proven.

## Where it's wired in and why
- It's a regular pipeline `stage`, not a `post { success }` block. `post` blocks are unreliable with Kubernetes/OpenShift pod agents (the pod backing the agent can already be torn down by the time `post` runs), so the retrigger runs as the last stage instead - it's naturally skipped if an earlier stage fails, same net effect as `post { success }` without that risk.
- It runs after the full `staging-build-repository` → `staging-copy-repository` → `staging-repoclosure` → `staging-test` → `staging-push-rpms` chain, i.e. only once the nightly RPMs have actually been staged, tested via `runDuffyPipeline`, and pushed - not right after the raw Copr/DEB build in `katello-master-package-release`. That job only builds packages, so triggering off it would rebuild Konflux images from packages that might still fail staging tests.
- `konflux_components` is defined in `pipelines/vars/katello/nightly.groovy`, which `katello-nightly-rpm-pipeline` already includes. `pipelines/release/pipelines/katello.groovy` is shared with the stable `katello-{version}-rpm-pipeline` jobs (4.20, 4.21), which use per-version vars files that don't define `konflux_components` - the stage's `when` guards on `binding.hasVariable('konflux_components')` so those jobs are unaffected.

## Discussion point for reviewers
Putting `konflux_components` in `pipelines/vars/katello/nightly.groovy` ties image rebuild triggering directly to the katello nightly pipeline's vars. That works for now, but two things make me want a second opinion on placement before we lean on it further:
- We're about to branch this (3.19 variants, `foreman-mcp-server-develop`), and those may not all map 1:1 to a single project's nightly vars file the way `candlepin-develop`/`pulp-develop` currently piggyback on katello's.
- Conceptually, Konflux image rebuilds aren't really "a katello pipeline concern" - e.g. an image containing only foreman (no katello) would have no natural home in `katello/nightly.groovy`.

Open to alternatives, e.g. a dedicated `pipelines/vars/konflux/nightly-components.groovy` (or similar) that's included explicitly by whichever pipeline(s) need to fire triggers, decoupling "which components rebuild" from "which project's nightly vars happen to run last."

## Test plan
- [x] `./test theforeman.org` passes locally (all jobs OK, including `katello-nightly-rpm-pipeline`, `katello-4.20-rpm-pipeline`, `katello-4.21-rpm-pipeline`, and `katello-master-package-release`, via the real declarative-pipeline validator against `ci.theforeman.org`)
- [ ] Confirm on a real run that the four `-develop` Konflux components get annotated and a rebuild is queued after a successful nightly pipeline