### PR TITLE
Fix konflux_components existence check in when expression

### DIFF
--- a/theforeman.org/pipelines/release/pipelines/katello.groovy
+++ b/theforeman.org/pipelines/release/pipelines/katello.groovy
@@ -67,7 +67,13 @@ pipeline {
         }
         stage('trigger-konflux-rebuild') {
             when {
-                expression { binding.hasVariable('konflux_components') && konflux_components }
+                expression {
+                    try {
+                        konflux_components as boolean
+                    } catch (MissingPropertyException ignored) {
+                        false
+                    }
+                }
             }
 
             steps {


### PR DESCRIPTION
## Summary
- The `trigger-konflux-rebuild` stage added in #584 was silently skipped on its first real run: https://ci.theforeman.org/view/Foreman%20Nightly/job/katello-nightly-rpm-pipeline/2853/ logged `Stage "trigger-konflux-rebuild" skipped due to when conditional` even though `konflux_components` is defined for the nightly pipeline.
- Root cause: `binding.hasVariable('konflux_components')` only detects implicit (non-`def`) script binding variables. `konflux_components` is declared with `def` in `pipelines/vars/katello/nightly.groovy`, so in the concatenated CPS script it's a genuine local variable, never registered in `Binding` — the guard was always `false`.
- Fix: reference `konflux_components` directly inside the `when { expression { ... } } }` block and catch `MissingPropertyException`. This works for the `def`-scoped nightly variable (direct lexical reference succeeds) while still protecting the `katello-4.20`/`katello-4.21` pipelines, where the variable is never declared at all (reference throws, caught, treated as absent) — same net effect as the old guard, but correct.

## Test plan
- [x] `./test theforeman.org` passes locally for `katello-nightly-rpm-pipeline`, `katello-4.20-rpm-pipeline`, `katello-4.21-rpm-pipeline`
- [ ] Confirm on the next nightly run that `trigger-konflux-rebuild` actually executes and annotates the four `-develop` components