### PR TITLE
Move konflux_* constants inside retrigger_konflux_components

### DIFF
--- a/theforeman.org/pipelines/lib/konflux.groovy
+++ b/theforeman.org/pipelines/lib/konflux.groovy
@@ -1,11 +1,11 @@
-def konflux_api_server = 'https://api.kflux-fedora-01.84db.p1.openshiftapps.com:6443'
-def konflux_namespace = 'theforeman-org-tenant'
-def konflux_oc_channel = 'stable'
-
 def retrigger_konflux_components(components) {
     if (!components) {
         return
     }
+
+    def konflux_api_server = 'https://api.kflux-fedora-01.84db.p1.openshiftapps.com:6443'
+    def konflux_namespace = 'theforeman-org-tenant'
+    def konflux_oc_channel = 'stable'
 
     def oc_dir = "${env.WORKSPACE}/bin"
     def oc_bin = "${oc_dir}/oc"


### PR DESCRIPTION
## Summary
- Follow-up to #585. With that fix merged, the `trigger-konflux-rebuild` stage now actually runs on nightly, but it immediately failed with:
  ```
  groovy.lang.MissingPropertyException: No such property: konflux_oc_channel for class: groovy.lang.Binding
      at WorkflowScript.retrigger_konflux_components(WorkflowScript:999)
  ```
- Root cause: `retrigger_konflux_components()` is a script **method** (`def name(args) { ... }`), not a closure. Closures capture the enclosing script's local (`def`) variables, but methods don't — they only see their own params/locals, instance fields, or `Binding` entries. `konflux_api_server`, `konflux_namespace`, and `konflux_oc_channel` were declared as top-level `def` locals in `pipelines/lib/konflux.groovy`, so they were invisible from inside the function body.
- Fix: since these three are only ever used inside `retrigger_konflux_components`, declare them as local variables of the method itself instead of the enclosing script scope.

## Test plan
- [x] `./test theforeman.org` passes locally for `katello-nightly-rpm-pipeline`, `katello-4.20-rpm-pipeline`, `katello-4.21-rpm-pipeline`
- [ ] Confirm on the next nightly run that `trigger-konflux-rebuild` completes and annotates the four `-develop` components