### PR TITLE
Use trigger-pac-build annotation value for Konflux rebuild

### DIFF
--- a/theforeman.org/pipelines/lib/konflux.groovy
+++ b/theforeman.org/pipelines/lib/konflux.groovy
@@ -38,7 +38,7 @@ def retrigger_konflux_components(components) {
             components.each { component ->
                 sh(
                     label: "trigger konflux rebuild: ${component}",
-                    script: "${oc_bin} annotate component ${component} --overwrite --namespace ${konflux_namespace} build.appstudio.openshift.io/request=trigger-rebuild"
+                    script: "${oc_bin} annotate component ${component} --overwrite --namespace ${konflux_namespace} build.appstudio.openshift.io/request=trigger-pac-build"
                 )
             }
         } finally {


### PR DESCRIPTION
## Summary
- The `trigger-konflux-rebuild` stage now runs successfully end-to-end (after #585 and #586), but the annotation value it uses, `build.appstudio.openshift.io/request=trigger-rebuild`, isn't a value the Konflux API recognizes, so no rebuild is actually queued.
- Per the [retriggering-a-post-merge-build docs](https://konflux-ci.dev/docs/building/running/#retriggering-a-post-merge-build-from-your-main-branch-from-the-api), the correct annotation is `build.appstudio.openshift.io/request=trigger-pac-build`.

## Test plan
- [x] `./test theforeman.org` passes locally for `katello-nightly-rpm-pipeline`
- [ ] Confirm on the next nightly run that the four `-develop` Konflux components actually get a new pipeline run queued (verifiable via `tkn pipelinerun list` per the docs)