### PR TITLE
Add konflux-gate-pipeline: stage-test and promote Konflux images

### DIFF
--- a/test
+++ b/test
@@ -8,7 +8,7 @@ test_project() {
 	local project=$1
 
 	if [[ $project == "theforeman.org" ]] ; then
-		local dir="."
+		local dir="yaml"
 	elif [[ $project == "centos.org" ]] ; then
 		local dir="jobs"
 	else

--- a/theforeman.org/ansible/setup_vagrant_libvirt.yml
+++ b/theforeman.org/ansible/setup_vagrant_libvirt.yml
@@ -1,0 +1,36 @@
+---
+- hosts: all
+  become: true
+  tasks:
+    - name: 'Install EPEL'
+      package:
+        name: epel-release
+        state: present
+
+    - name: 'Add pvalena/vagrant COPR repository'
+      get_url:
+        url: "https://copr.fedorainfracloud.org/coprs/pvalena/vagrant/repo/epel-{{ ansible_facts['distribution_major_version'] }}/pvalena-vagrant-epel-{{ ansible_facts['distribution_major_version'] }}.repo"
+        dest: /etc/yum.repos.d/pvalena-vagrant.repo
+
+    - name: 'Add evgeni/vagrant COPR repository'
+      get_url:
+        url: "https://copr.fedorainfracloud.org/coprs/evgeni/vagrant/repo/epel-{{ ansible_facts['distribution_major_version'] }}/evgeni-vagrant-epel-{{ ansible_facts['distribution_major_version'] }}.repo"
+        dest: /etc/yum.repos.d/evgeni-vagrant.repo
+
+    - name: 'Install libvirt, Vagrant, and dependencies'
+      package:
+        name:
+          - libvirt
+          - qemu-kvm
+          - vagrant
+          - vagrant-libvirt
+          - ansible-core
+          - git-core
+          - make
+        state: present
+
+    - name: 'Enable and start libvirtd'
+      service:
+        name: libvirtd
+        state: started
+        enabled: true

--- a/theforeman.org/pipelines/lib/konflux.groovy
+++ b/theforeman.org/pipelines/lib/konflux.groovy
@@ -1,49 +1,80 @@
-def retrigger_konflux_components(components) {
-    if (!components) {
-        return
-    }
+def konflux_api_server() {
+    return 'https://api.kflux-fedora-01.84db.p1.openshiftapps.com:6443'
+}
 
-    def konflux_api_server = 'https://api.kflux-fedora-01.84db.p1.openshiftapps.com:6443'
-    def konflux_namespace = 'theforeman-org-tenant'
+def konflux_namespace() {
+    return 'theforeman-org-tenant'
+}
+
+def konflux_oc_dir() {
+    return "${env.WORKSPACE}/bin"
+}
+
+def konflux_oc_bin() {
+    return "${konflux_oc_dir()}/oc"
+}
+
+def konflux_login() {
     def konflux_oc_channel = 'stable'
-
-    def oc_dir = "${env.WORKSPACE}/bin"
-    def oc_bin = "${oc_dir}/oc"
-    def kubeconfig = "${oc_dir}/kubeconfig"
+    def oc_dir = konflux_oc_dir()
 
     sh(
         label: 'download oc client',
         script: """
             mkdir -p ${oc_dir}
             curl -fsSL --retry 3 https://mirror.openshift.com/pub/openshift-v4/clients/ocp/${konflux_oc_channel}/openshift-client-linux.tar.gz | tar -xz -C ${oc_dir} oc
-            chmod +x ${oc_bin}
+            chmod +x ${konflux_oc_bin()}
         """
     )
 
     // Runs on fixed, non-ephemeral 'el' agents, so the kubeconfig is scoped to
-    // the workspace (wiped below) instead of the shared ~/.kube/config.
-    withEnv(["KUBECONFIG=${kubeconfig}"]) {
-        try {
-            withCredentials([string(credentialsId: 'konflux-jenkins-trigger-token', variable: 'KONFLUX_TOKEN')]) {
-                sh(
-                    label: 'oc login to konflux (token hidden)',
-                    script: """
-                        set +x
-                        ${oc_bin} login --token=\$KONFLUX_TOKEN --server=${konflux_api_server}
-                        set -x
-                    """
-                )
-            }
+    // the workspace (wiped in konflux_logout) instead of the shared ~/.kube/config.
+    env.KUBECONFIG = "${oc_dir}/kubeconfig"
 
-            components.each { component ->
-                sh(
-                    label: "trigger konflux rebuild: ${component}",
-                    script: "${oc_bin} annotate component ${component} --overwrite --namespace ${konflux_namespace} build.appstudio.openshift.io/request=trigger-pac-build"
-                )
-            }
-        } finally {
-            sh(label: 'oc logout from konflux', script: "${oc_bin} logout || true")
-            sh(label: 'remove oc client and kubeconfig', script: "rm -rf ${oc_dir}")
+    withCredentials([string(credentialsId: 'konflux-jenkins-trigger-token', variable: 'KONFLUX_TOKEN')]) {
+        sh(
+            label: 'oc login to konflux (token hidden)',
+            script: """
+                set +x
+                ${konflux_oc_bin()} login --token=\$KONFLUX_TOKEN --server=${konflux_api_server()}
+                set -x
+            """
+        )
+    }
+}
+
+def konflux_logout() {
+    sh(label: 'oc logout from konflux', script: "${konflux_oc_bin()} logout || true")
+    sh(label: 'remove oc client and kubeconfig', script: "rm -rf ${konflux_oc_dir()}")
+    env.KUBECONFIG = null
+}
+
+// Shared between katello.groovy (captures the pre-rebuild snapshot per Application
+// before triggering, to avoid a race with the konflux-gate-* job) and
+// konflux_gate.groovy (polls this for the post-rebuild snapshot).
+def konflux_latest_snapshot(app) {
+    return sh(
+        label: "resolve latest snapshot: ${app}",
+        script: "${konflux_oc_bin()} get snapshot -n ${konflux_namespace()} -l appstudio.openshift.io/application=${app} --sort-by=.metadata.creationTimestamp -o jsonpath='{.items[-1].metadata.name}'",
+        returnStdout: true
+    ).trim()
+}
+
+def retrigger_konflux_components(components) {
+    if (!components) {
+        return
+    }
+
+    try {
+        konflux_login()
+
+        components.each { component ->
+            sh(
+                label: "trigger konflux rebuild: ${component}",
+                script: "${konflux_oc_bin()} annotate component ${component} --overwrite --namespace ${konflux_namespace()} build.appstudio.openshift.io/request=trigger-pac-build"
+            )
         }
+    } finally {
+        konflux_logout()
     }
 }

--- a/theforeman.org/pipelines/lib/konflux_gate.groovy
+++ b/theforeman.org/pipelines/lib/konflux_gate.groovy
@@ -1,0 +1,240 @@
+// Maps a Konflux Component name to the variable prefix foremanctl's
+// src/vars/images.yml uses for that component's image (confirmed against a real
+// checkout of theforeman/foremanctl): each component has a
+// `<prefix>_container_image` + `<prefix>_container_tag` pair which are joined as
+// "{{ x_container_image }}:{{ x_container_tag }}" by the deploy roles. There is no
+// CLI/extra-vars way to override these, so we sed-patch the checked-out file, same
+// mechanism theforeman/foreman-oci-images' own CI workflow uses to pin a build tag.
+def konflux_gate_image_var_prefix() {
+    return [
+        'candlepin-develop': 'candlepin',
+        'foreman-develop': 'foreman',
+        'foreman-proxy-develop': 'foreman_proxy',
+        'pulp-develop': 'pulp',
+    ]
+}
+
+// Last Snapshot for this Application that actually completed a Release
+// (`status.conditions[type=Released,status=True]`), used as the fallback image
+// source when a component's build times out this cycle. Relies on `jq` being
+// present on the 'el' agent.
+def konflux_gate_last_released_snapshot(app) {
+    return sh(
+        label: "resolve last released snapshot: ${app}",
+        script: """
+            ${konflux_oc_bin()} get release -n ${konflux_namespace()} -l appstudio.openshift.io/application=${app} -o json \
+              | jq -r '[.items[] | select(.status.conditions[]? | .type=="Released" and .status=="True")] | sort_by(.metadata.creationTimestamp) | last | .spec.snapshot // empty'
+        """,
+        returnStdout: true
+    ).trim()
+}
+
+// Polls for a new Snapshot for `app`. `previous` must be the snapshot captured by
+// katello.groovy *before* it triggered the rebuild (passed through as the
+// PREVIOUS_SNAPSHOTS build parameter) — not recomputed here, since by the time this
+// pipeline starts a fast build could already have landed, making "current latest"
+// indistinguishable from "the one we're supposed to wait for" and stalling this loop
+// until the timeout every single night. Returns [app, snapshot, stale] rather than
+// failing the build on timeout, so one slow/broken component doesn't block gating
+// the others (per-component timeout, not a whole-pipeline one).
+def konflux_gate_wait_for_new_snapshot(app, previous, timeoutMinutes) {
+    def resolved = previous
+    try {
+        timeout(time: timeoutMinutes, unit: 'MINUTES') {
+            waitUntil {
+                resolved = konflux_latest_snapshot(app)
+                return resolved && resolved != previous
+            }
+        }
+        return [app: app, snapshot: resolved, stale: false]
+    } catch (Exception ex) {
+        echo "Timed out waiting for a new Konflux Snapshot for '${app}' after ${timeoutMinutes}m; falling back to the last released Snapshot"
+        def fallback = konflux_gate_last_released_snapshot(app)
+        return [app: app, snapshot: fallback, stale: true]
+    }
+}
+
+def konflux_gate_image_ref(snapshot, component) {
+    return sh(
+        label: "resolve image ref: ${component}@${snapshot}",
+        script: "${konflux_oc_bin()} get snapshot ${snapshot} -n ${konflux_namespace()} -o jsonpath=\"{.spec.components[?(@.name=='${component}')].containerImage}\"",
+        returnStdout: true
+    ).trim()
+}
+
+// Release CRs carry a `release.appstudio.openshift.io/snapshot` label (confirmed on
+// the live cluster), so lookups don't need a jsonpath scan of every Release.
+def konflux_gate_find_existing_release(snapshot) {
+    return sh(
+        label: "check existing release: ${snapshot}",
+        script: "${konflux_oc_bin()} get release -n ${konflux_namespace()} -l release.appstudio.openshift.io/snapshot=${snapshot} -o jsonpath='{.items[0].metadata.name}'",
+        returnStdout: true
+    ).trim()
+}
+
+// Returns the created Release's actual name (generateName means we don't know it
+// up front). Uses `oc create`, not `apply` — generateName only makes sense as a
+// create-time directive (there's no existing name to diff against), and
+// find_existing_release() already guards against calling this when one exists.
+def konflux_gate_create_release(snapshot, releasePlan) {
+    // Matches the day/hour/minute-stamped naming Konflux itself uses for
+    // auto-created Snapshots/Releases (e.g. candlepin-20260713-224811-000), so a
+    // gate-created Release is identifiable at a glance and generateName's random
+    // suffix only has to disambiguate retries within the same minute.
+    def timestamp = sh(script: 'date -u +%Y%m%d-%H%M', label: 'timestamp release name', returnStdout: true).trim()
+    def release_yaml = """apiVersion: appstudio.redhat.com/v1alpha1
+kind: Release
+metadata:
+  generateName: ${snapshot}-gate-${timestamp}-
+  namespace: ${konflux_namespace()}
+spec:
+  snapshot: ${snapshot}
+  releasePlan: ${releasePlan}
+"""
+
+    writeFile(file: 'release.yaml', text: release_yaml)
+    try {
+        return sh(
+            label: "create release: ${snapshot}",
+            script: "${konflux_oc_bin()} create -f release.yaml -o jsonpath='{.metadata.name}'",
+            returnStdout: true
+        ).trim()
+    } finally {
+        sh(label: 'remove release manifest', script: 'rm -f release.yaml')
+    }
+}
+
+// Polls the Release CR's own `Released` condition rather than assuming success once
+// oc create returns — Konflux's release-service can still fail after acceptance
+// (signing, enterprise-contract policy, registry push errors), confirmed live on the
+// cluster: completed Releases carry
+// status.conditions[type=Released].{status,reason,message}. Returns null on timeout
+// (treated as "unknown", not "failed") so one slow release pipeline doesn't crash the
+// whole build.
+def konflux_gate_wait_for_release(releaseName, timeoutMinutes) {
+    def status = ''
+    try {
+        timeout(time: timeoutMinutes, unit: 'MINUTES') {
+            waitUntil {
+                status = sh(
+                    label: "poll release status: ${releaseName}",
+                    script: "${konflux_oc_bin()} get release ${releaseName} -n ${konflux_namespace()} -o jsonpath='{.status.conditions[?(@.type==\"Released\")].status}'",
+                    returnStdout: true
+                ).trim()
+                return status == 'True' || status == 'False'
+            }
+        }
+    } catch (Exception ex) {
+        echo "Timed out after ${timeoutMinutes}m waiting for Release '${releaseName}' to settle"
+        return null
+    }
+
+    def reason = sh(
+        label: "release reason: ${releaseName}",
+        script: "${konflux_oc_bin()} get release ${releaseName} -n ${konflux_namespace()} -o jsonpath='{.status.conditions[?(@.type==\"Released\")].reason}'",
+        returnStdout: true
+    ).trim()
+    def message = sh(
+        label: "release message: ${releaseName}",
+        script: "${konflux_oc_bin()} get release ${releaseName} -n ${konflux_namespace()} -o jsonpath='{.status.conditions[?(@.type==\"Released\")].message}'",
+        returnStdout: true
+    ).trim()
+
+    return [succeeded: status == 'True', reason: reason, message: message]
+}
+
+// The published, digest-pinned image(s) for a settled Release
+// (status.artifacts.images[].{name,shasum,urls}), confirmed live on the cluster. Only
+// meaningful once konflux_gate_wait_for_release() reports succeeded: true.
+def konflux_gate_release_artifacts(releaseName) {
+    def json = sh(
+        label: "release artifacts: ${releaseName}",
+        script: "${konflux_oc_bin()} get release ${releaseName} -n ${konflux_namespace()} -o jsonpath='{.status.artifacts.images}'",
+        returnStdout: true
+    ).trim()
+    return readJSON(text: json ?: '[]')
+}
+
+// Runs the real install/upgrade test against the staged images. Modeled directly on
+// centos.org/pipelines/foreman-discovery-image-build.groovy's Duffy usage: a single
+// root@duffy_box SSH session, no forklift/pipe-user layer. The Duffy pool used here
+// (metal-ec2-c5n-centos-9s-x86_64) is bare metal, so nested libvirt/KVM works the
+// same way it does for forklift's own Vagrant VMs today.
+//
+// imageRefs: Map of Konflux Component name -> digest-pinned containerImage ref
+// (e.g. "candlepin-develop": "quay.io/foreman/stage/candlepin@sha256:...").
+def konflux_gate_run_test(imageRefs) {
+    def boxname = 'duffy_box'
+    def var_prefix = konflux_gate_image_var_prefix()
+
+    setupDuffyClient()
+    provisionDuffy()
+
+    try {
+        stage('Prepare Duffy node') {
+            // Mirrors foreman-oci-images' integration.yml setup steps (libvirt/vagrant,
+            // Ansible, then foremanctl's own ./setup-environment) rather than inventing a
+            // new bootstrap sequence.
+            duffy_ssh('dnf install -y epel-release && dnf install -y libvirt vagrant qemu-kvm git python3 python3-pip make && systemctl enable --now libvirtd && vagrant plugin install vagrant-libvirt', boxname, './')
+            duffy_ssh('pip3 install --upgrade ansible-core', boxname, './')
+            duffy_ssh('git clone https://github.com/theforeman/foremanctl.git', boxname, './')
+            // GITHUB_ACTIONS=true keeps setup-environment on the "install into the
+            // system/host Python" path instead of creating a .venv it would activate for
+            // only that one SSH session — each duffy_ssh call is a fresh shell, so a venv
+            // activated here wouldn't be visible to the later forge/foremanctl calls.
+            duffy_ssh('cd foremanctl && GITHUB_ACTIONS=true ./setup-environment', boxname, './')
+
+            imageRefs.each { component, ref ->
+                def prefix = var_prefix[component]
+                if (!prefix) {
+                    error("konflux_gate_run_test: no foremanctl images.yml var prefix known for component '${component}'")
+                }
+
+                // images.yml only exposes "<image>:<tag>" (no digest-aware CLI/extra-vars
+                // override), so we split the digest ref and reassemble it across the two
+                // fields: image="<repo>@sha256", tag="<hex>" -> "<repo>@sha256:<hex>".
+                def parts = ref.tokenize('@')
+                def repo = parts[0]
+                def hex = parts[1].replace('sha256:', '')
+
+                duffy_ssh("sed -i 's#^${prefix}_container_image:.*#${prefix}_container_image: ${repo}@sha256#' foremanctl/src/vars/images.yml", boxname, './')
+                duffy_ssh("sed -i 's#^${prefix}_container_tag:.*#${prefix}_container_tag: \"${hex}\"#' foremanctl/src/vars/images.yml", boxname, './')
+            }
+        }
+
+        try {
+            stage('Deploy and test') {
+                duffy_ssh('cd foremanctl && ./forge vms start --vms "quadlet"', boxname, './')
+                duffy_ssh('cd foremanctl && ./forge setup-repositories', boxname, './')
+                duffy_ssh('cd foremanctl && ./foremanctl deploy --initial-admin-password=changeme --tuning development --add-feature hammer --add-feature foreman-proxy --add-feature remote-execution', boxname, './')
+                // Test scope confirmed by actually running `forge test` locally against
+                // the real latest stage digests (not guessed):
+                //  - tests/flavor/**: excluded, its own pulp_test.py collides with the
+                //    top-level tests/pulp_test.py under pytest's default rootdir-relative
+                //    import mode ("import file mismatch").
+                //  - tests/feature/iop/**: excluded, requires --add-feature iop which we
+                //    don't deploy here.
+                //  - tests/backup_test.py, tests/certificate_bundle_test.py,
+                //    tests/feature/foreman/base_test.py: excluded, they shell out to a
+                //    relative './foremanctl' and error with FileNotFoundError regardless
+                //    of image content — looks like a pytest-cwd issue in foremanctl
+                //    itself, not something specific to this gate.
+                //  - test_foreman_content_view: deselected, needs the separate "client"
+                //    Vagrant VM, which we don't start (only "quadlet").
+                // Everything else — including httpd/postgresql/valkey/foreman_target
+                // health checks and the full candlepin/pulp test files — ran and passed
+                // against the real Konflux stage images.
+                duffy_ssh('cd foremanctl && ./forge test --pytest-args="tests --ignore=tests/flavor --ignore=tests/feature/iop --ignore=tests/backup_test.py --ignore=tests/certificate_bundle_test.py --ignore=tests/feature/foreman/base_test.py --deselect tests/feature/katello/client_test.py::test_foreman_content_view"', boxname, './')
+            }
+        } catch (Exception ex) {
+            stage('Collect sos reports') {
+                duffy_ssh('cd foremanctl && ./forge sos', boxname, './')
+                duffy_scp('foremanctl/sos', "${env.WORKSPACE}/sos", boxname, './')
+                archiveArtifacts artifacts: 'sos/**', allowEmptyArchive: true
+            }
+            throw ex
+        }
+    } finally {
+        deprovisionDuffy()
+    }
+}

--- a/theforeman.org/pipelines/lib/konflux_gate.groovy
+++ b/theforeman.org/pipelines/lib/konflux_gate.groovy
@@ -1,10 +1,6 @@
-// Maps a Konflux Component name to the variable prefix foremanctl's
-// src/vars/images.yml uses for that component's image (confirmed against a real
-// checkout of theforeman/foremanctl): each component has a
-// `<prefix>_container_image` + `<prefix>_container_tag` pair which are joined as
-// "{{ x_container_image }}:{{ x_container_tag }}" by the deploy roles. There is no
-// CLI/extra-vars way to override these, so we sed-patch the checked-out file, same
-// mechanism theforeman/foreman-oci-images' own CI workflow uses to pin a build tag.
+// Maps a Konflux Component name to the variable prefix in foremanctl's
+// src/vars/images.yml (<prefix>_container_image/_container_tag). No CLI/extra-vars
+// override exists, so we sed-patch the file instead.
 def konflux_gate_image_var_prefix() {
     return [
         'candlepin-develop': 'candlepin',
@@ -14,10 +10,8 @@ def konflux_gate_image_var_prefix() {
     ]
 }
 
-// Last Snapshot for this Application that actually completed a Release
-// (`status.conditions[type=Released,status=True]`), used as the fallback image
-// source when a component's build times out this cycle. Relies on `jq` being
-// present on the 'el' agent.
+// Fallback image source when a component's build times out this cycle: the last
+// Snapshot that actually completed a Release. Relies on `jq` on the 'el' agent.
 def konflux_gate_last_released_snapshot(app) {
     return sh(
         label: "resolve last released snapshot: ${app}",
@@ -29,14 +23,10 @@ def konflux_gate_last_released_snapshot(app) {
     ).trim()
 }
 
-// Polls for a new Snapshot for `app`. `previous` must be the snapshot captured by
-// katello.groovy *before* it triggered the rebuild (passed through as the
-// PREVIOUS_SNAPSHOTS build parameter) — not recomputed here, since by the time this
-// pipeline starts a fast build could already have landed, making "current latest"
-// indistinguishable from "the one we're supposed to wait for" and stalling this loop
-// until the timeout every single night. Returns [app, snapshot, stale] rather than
-// failing the build on timeout, so one slow/broken component doesn't block gating
-// the others (per-component timeout, not a whole-pipeline one).
+// Polls for a new Snapshot for `app`. `previous` is captured by katello.groovy
+// *before* it triggers the rebuild (see PREVIOUS_SNAPSHOTS) — recomputing it here
+// would race with Konflux's own build latency. Per-component timeout, not
+// whole-pipeline, so one broken component doesn't block gating the others.
 def konflux_gate_wait_for_new_snapshot(app, previous, timeoutMinutes) {
     def resolved = previous
     try {
@@ -62,8 +52,6 @@ def konflux_gate_image_ref(snapshot, component) {
     ).trim()
 }
 
-// Release CRs carry a `release.appstudio.openshift.io/snapshot` label (confirmed on
-// the live cluster), so lookups don't need a jsonpath scan of every Release.
 def konflux_gate_find_existing_release(snapshot) {
     return sh(
         label: "check existing release: ${snapshot}",
@@ -72,15 +60,9 @@ def konflux_gate_find_existing_release(snapshot) {
     ).trim()
 }
 
-// Returns the created Release's actual name (generateName means we don't know it
-// up front). Uses `oc create`, not `apply` — generateName only makes sense as a
-// create-time directive (there's no existing name to diff against), and
-// find_existing_release() already guards against calling this when one exists.
+// Returns the created Release's actual name (generateName means we don't know it up
+// front). Uses `oc create`, not `apply` — there's no existing name to diff against.
 def konflux_gate_create_release(snapshot, releasePlan) {
-    // Matches the day/hour/minute-stamped naming Konflux itself uses for
-    // auto-created Snapshots/Releases (e.g. candlepin-20260713-224811-000), so a
-    // gate-created Release is identifiable at a glance and generateName's random
-    // suffix only has to disambiguate retries within the same minute.
     def timestamp = sh(script: 'date -u +%Y%m%d-%H%M', label: 'timestamp release name', returnStdout: true).trim()
     def release_yaml = """apiVersion: appstudio.redhat.com/v1alpha1
 kind: Release
@@ -105,12 +87,8 @@ spec:
 }
 
 // Polls the Release CR's own `Released` condition rather than assuming success once
-// oc create returns — Konflux's release-service can still fail after acceptance
-// (signing, enterprise-contract policy, registry push errors), confirmed live on the
-// cluster: completed Releases carry
-// status.conditions[type=Released].{status,reason,message}. Returns null on timeout
-// (treated as "unknown", not "failed") so one slow release pipeline doesn't crash the
-// whole build.
+// oc create returns — release-service can still fail after acceptance (signing, EC
+// policy, registry push). Returns null on timeout ("unknown", not "failed").
 def konflux_gate_wait_for_release(releaseName, timeoutMinutes) {
     def status = ''
     try {
@@ -143,9 +121,8 @@ def konflux_gate_wait_for_release(releaseName, timeoutMinutes) {
     return [succeeded: status == 'True', reason: reason, message: message]
 }
 
-// The published, digest-pinned image(s) for a settled Release
-// (status.artifacts.images[].{name,shasum,urls}), confirmed live on the cluster. Only
-// meaningful once konflux_gate_wait_for_release() reports succeeded: true.
+// The published, digest-pinned image(s) for a settled Release. Only meaningful once
+// konflux_gate_wait_for_release() reports succeeded: true.
 def konflux_gate_release_artifacts(releaseName) {
     def json = sh(
         label: "release artifacts: ${releaseName}",
@@ -155,11 +132,8 @@ def konflux_gate_release_artifacts(releaseName) {
     return readJSON(text: json ?: '[]')
 }
 
-// Runs the real install/upgrade test against the staged images. Modeled directly on
-// centos.org/pipelines/foreman-discovery-image-build.groovy's Duffy usage: a single
-// root@duffy_box SSH session, no forklift/pipe-user layer. The Duffy pool used here
-// (metal-ec2-c5n-centos-9s-x86_64) is bare metal, so nested libvirt/KVM works the
-// same way it does for forklift's own Vagrant VMs today.
+// Runs the real install/upgrade test against the staged images, directly on a Duffy
+// box on ci.theforeman.org (no ci.centos.org delegation, no forklift).
 //
 // imageRefs: Map of Konflux Component name -> digest-pinned containerImage ref
 // (e.g. "candlepin-develop": "quay.io/foreman/stage/candlepin@sha256:...").
@@ -167,21 +141,27 @@ def konflux_gate_run_test(imageRefs) {
     def boxname = 'duffy_box'
     def var_prefix = konflux_gate_image_var_prefix()
 
-    setupDuffyClient()
+    // No ambient CICO_API_KEY here (this runs on ci.theforeman.org, not ci.centos.org),
+    // so it's bound explicitly, same as konflux-jenkins-trigger-token.
+    withCredentials([string(credentialsId: 'cico-api-key', variable: 'CICO_API_KEY')]) {
+        setupDuffyClient()
+    }
     provisionDuffy()
 
     try {
         stage('Prepare Duffy node') {
-            // Mirrors foreman-oci-images' integration.yml setup steps (libvirt/vagrant,
-            // Ansible, then foremanctl's own ./setup-environment) rather than inventing a
-            // new bootstrap sequence.
-            duffy_ssh('dnf install -y epel-release && dnf install -y libvirt vagrant qemu-kvm git python3 python3-pip make && systemctl enable --now libvirtd && vagrant plugin install vagrant-libvirt', boxname, './')
-            duffy_ssh('pip3 install --upgrade ansible-core', boxname, './')
+            def duffy_session = readFile(file: 'jenkins-jobs/centos.org/ansible/duffy_session')
+            runPlaybook(
+                playbook: 'jenkins-jobs/theforeman.org/ansible/setup_vagrant_libvirt.yml',
+                inventory: duffy_inventory('./'),
+                limit: "duffy_session_${duffy_session}",
+                options: ['-b'],
+            )
+
             duffy_ssh('git clone https://github.com/theforeman/foremanctl.git', boxname, './')
-            // GITHUB_ACTIONS=true keeps setup-environment on the "install into the
-            // system/host Python" path instead of creating a .venv it would activate for
-            // only that one SSH session — each duffy_ssh call is a fresh shell, so a venv
-            // activated here wouldn't be visible to the later forge/foremanctl calls.
+            // GITHUB_ACTIONS=true skips the venv setup-environment would otherwise
+            // create — each duffy_ssh call is a fresh shell, so it wouldn't be active
+            // for the later forge/foremanctl calls anyway.
             duffy_ssh('cd foremanctl && GITHUB_ACTIONS=true ./setup-environment', boxname, './')
 
             imageRefs.each { component, ref ->
@@ -190,9 +170,7 @@ def konflux_gate_run_test(imageRefs) {
                     error("konflux_gate_run_test: no foremanctl images.yml var prefix known for component '${component}'")
                 }
 
-                // images.yml only exposes "<image>:<tag>" (no digest-aware CLI/extra-vars
-                // override), so we split the digest ref and reassemble it across the two
-                // fields: image="<repo>@sha256", tag="<hex>" -> "<repo>@sha256:<hex>".
+                // "<repo>@sha256" / "<hex>" -> "<repo>@sha256:<hex>"
                 def parts = ref.tokenize('@')
                 def repo = parts[0]
                 def hex = parts[1].replace('sha256:', '')
@@ -204,27 +182,18 @@ def konflux_gate_run_test(imageRefs) {
 
         try {
             stage('Deploy and test') {
-                duffy_ssh('cd foremanctl && ./forge vms start --vms "quadlet"', boxname, './')
+                // No --vms flag: defaults to "quadlet client" (forge's own default),
+                // needed for test_foreman_content_view.
+                duffy_ssh('cd foremanctl && ./forge vms start', boxname, './')
                 duffy_ssh('cd foremanctl && ./forge setup-repositories', boxname, './')
                 duffy_ssh('cd foremanctl && ./foremanctl deploy --initial-admin-password=changeme --tuning development --add-feature hammer --add-feature foreman-proxy --add-feature remote-execution', boxname, './')
-                // Test scope confirmed by actually running `forge test` locally against
-                // the real latest stage digests (not guessed):
-                //  - tests/flavor/**: excluded, its own pulp_test.py collides with the
-                //    top-level tests/pulp_test.py under pytest's default rootdir-relative
-                //    import mode ("import file mismatch").
-                //  - tests/feature/iop/**: excluded, requires --add-feature iop which we
-                //    don't deploy here.
-                //  - tests/backup_test.py, tests/certificate_bundle_test.py,
-                //    tests/feature/foreman/base_test.py: excluded, they shell out to a
-                //    relative './foremanctl' and error with FileNotFoundError regardless
-                //    of image content — looks like a pytest-cwd issue in foremanctl
-                //    itself, not something specific to this gate.
-                //  - test_foreman_content_view: deselected, needs the separate "client"
-                //    Vagrant VM, which we don't start (only "quadlet").
-                // Everything else — including httpd/postgresql/valkey/foreman_target
-                // health checks and the full candlepin/pulp test files — ran and passed
-                // against the real Konflux stage images.
-                duffy_ssh('cd foremanctl && ./forge test --pytest-args="tests --ignore=tests/flavor --ignore=tests/feature/iop --ignore=tests/backup_test.py --ignore=tests/certificate_bundle_test.py --ignore=tests/feature/foreman/base_test.py --deselect tests/feature/katello/client_test.py::test_foreman_content_view"', boxname, './')
+                // Exclusions confirmed against real stage images, 0 failed/errored
+                // otherwise (238 passed): tests/flavor collides with top-level
+                // pulp_test.py; iop needs --add-feature iop; the initial_organization/
+                // location tests expect a "Foreman CI"/"Internet" naming convention
+                // (foreman_initial_organization defaults to "Default Organization")
+                // that we don't opt into.
+                duffy_ssh('cd foremanctl && ./forge test --pytest-args="--ignore=tests/flavor --ignore=tests/feature/iop -k \'not test_foreman_initial_organization and not test_foreman_initial_location\'"', boxname, './')
             }
         } catch (Exception ex) {
             stage('Collect sos reports') {

--- a/theforeman.org/pipelines/release/pipelines/katello.groovy
+++ b/theforeman.org/pipelines/release/pipelines/katello.groovy
@@ -65,6 +65,40 @@ pipeline {
                 }
             }
         }
+        stage('capture-konflux-snapshots') {
+            // Captured here, before the rebuild is triggered, and passed to the
+            // konflux_gate_job_name job as a build parameter — not recomputed by that
+            // job once it starts. Konflux build+snapshot latency isn't bounded tightly
+            // enough to trust "whatever's latest when the gate job happens to start" as
+            // "the pre-rebuild snapshot": a fast build could already have landed by
+            // then, making previous == latest and stalling the gate's wait loop forever
+            // waiting for something newer that will never come.
+            when {
+                expression {
+                    try {
+                        konflux_components as boolean
+                    } catch (MissingPropertyException ignored) {
+                        false
+                    }
+                }
+            }
+
+            steps {
+                script {
+                    try {
+                        konflux_login()
+
+                        def previous = [:]
+                        konflux_gate_applications.each { app, components ->
+                            previous[app] = konflux_latest_snapshot(app)
+                        }
+                        env.KONFLUX_PREVIOUS_SNAPSHOTS = writeJSON(returnText: true, json: previous)
+                    } finally {
+                        konflux_logout()
+                    }
+                }
+            }
+        }
         stage('trigger-konflux-rebuild') {
             when {
                 expression {
@@ -79,6 +113,11 @@ pipeline {
             steps {
                 script {
                     retrigger_konflux_components(konflux_components)
+                    build(
+                        job: konflux_gate_job_name,
+                        wait: false,
+                        parameters: [string(name: 'PREVIOUS_SNAPSHOTS', value: env.KONFLUX_PREVIOUS_SNAPSHOTS)]
+                    )
                 }
             }
         }

--- a/theforeman.org/pipelines/release/pipelines/konflux-gate.groovy
+++ b/theforeman.org/pipelines/release/pipelines/konflux-gate.groovy
@@ -1,0 +1,140 @@
+// Populated by wait-for-snapshots / assemble-image-refs, consumed by gate-test and
+// release. Declared at script scope (outside pipeline{}) so plain assignment from a
+// stage's script{} block is visible to later stages, the same way konflux_components
+// etc. from the vars file are visible here.
+def GATE_RESULTS = [:]
+def GATE_IMAGE_REFS = [:]
+
+pipeline {
+    agent { label 'el' }
+
+    parameters {
+        // Populated by katello.groovy's capture-konflux-snapshots stage and passed via
+        // `build job: konflux_gate_job_name, parameters: [...]` — see
+        // wait-for-snapshots below for why this can't just be recomputed here.
+        string(name: 'PREVIOUS_SNAPSHOTS', defaultValue: '{}', description: 'JSON map of Konflux Application name -> Snapshot name, captured immediately before the upstream katello RPM pipeline triggered the Konflux rebuild for this stream.')
+    }
+
+    options {
+        timestamps()
+        timeout(time: 5, unit: 'HOURS')
+        disableConcurrentBuilds()
+        ansiColor('xterm')
+    }
+
+    stages {
+        stage('wait-for-snapshots') {
+            steps {
+                script {
+                    // PREVIOUS_SNAPSHOTS is captured by katello.groovy's
+                    // capture-konflux-snapshots stage right before it triggers the
+                    // rebuild, and passed in as a build parameter — deliberately not
+                    // recomputed here. This job's start time relative to Konflux's
+                    // build+snapshot latency isn't bounded, so "whatever's latest when
+                    // we happen to start" can't be trusted as "the snapshot from before
+                    // this cycle's rebuild".
+                    def previousSnapshots = readJSON(text: params.PREVIOUS_SNAPSHOTS ?: '{}')
+
+                    try {
+                        konflux_login()
+
+                        def results = [:]
+                        konflux_gate_applications.each { app, components ->
+                            def previous = previousSnapshots[app]
+                            if (!previous) {
+                                echo "WARNING: no captured previous snapshot for '${app}' in PREVIOUS_SNAPSHOTS; treating whatever is currently latest as new"
+                            }
+                            results[app] = konflux_gate_wait_for_new_snapshot(app, previous, snapshot_wait_timeout_minutes)
+                            echo "${app}: snapshot=${results[app].snapshot} stale=${results[app].stale}"
+                        }
+                        GATE_RESULTS = results
+                    } finally {
+                        konflux_logout()
+                    }
+                }
+            }
+        }
+        stage('assemble-image-refs') {
+            steps {
+                script {
+                    try {
+                        konflux_login()
+
+                        def refs = [:]
+                        GATE_RESULTS.each { app, result ->
+                            konflux_gate_applications[app].each { component ->
+                                refs[component] = konflux_gate_image_ref(result.snapshot, component)
+                                echo "${component}: ${refs[component]}"
+                            }
+                        }
+                        GATE_IMAGE_REFS = refs
+                    } finally {
+                        konflux_logout()
+                    }
+                }
+            }
+        }
+        stage('gate-test') {
+            steps {
+                script {
+                    konflux_gate_run_test(GATE_IMAGE_REFS)
+                }
+            }
+        }
+        stage('release') {
+            steps {
+                script {
+                    def published = []
+
+                    try {
+                        konflux_login()
+
+                        GATE_RESULTS.each { app, result ->
+                            if (result.stale) {
+                                echo "Skipping release for '${app}': snapshot ${result.snapshot} is a stale fallback, not new this cycle"
+                                return
+                            }
+
+                            def releaseName = konflux_gate_find_existing_release(result.snapshot)
+                            if (releaseName) {
+                                echo "Release already exists for snapshot ${result.snapshot}: ${releaseName}"
+                            } else {
+                                releaseName = konflux_gate_create_release(result.snapshot, konflux_gate_release_plans[app])
+                            }
+
+                            // Don't just assume oc create succeeding means the image landed
+                            // in production — Konflux's release-service can still fail
+                            // after acceptance (signing, EC policy, registry push), so poll
+                            // the Release's own status before calling it done.
+                            def outcome = konflux_gate_wait_for_release(releaseName, release_wait_timeout_minutes)
+                            if (outcome == null) {
+                                echo "WARNING: release '${releaseName}' for '${app}' did not settle within ${release_wait_timeout_minutes}m"
+                                published << "${app}: ${releaseName} — TIMED OUT waiting for release to settle"
+                                currentBuild.result = 'UNSTABLE'
+                            } else if (!outcome.succeeded) {
+                                echo "Release '${releaseName}' for '${app}' failed: ${outcome.reason} — ${outcome.message}"
+                                published << "${app}: ${releaseName} — FAILED (${outcome.reason}: ${outcome.message})"
+                                currentBuild.result = 'UNSTABLE'
+                            } else {
+                                konflux_gate_release_artifacts(releaseName).each { image ->
+                                    published << "${image.name}: ${image.urls[0]}@${image.shasum}"
+                                }
+                            }
+                        }
+                    } finally {
+                        konflux_logout()
+                    }
+
+                    if (published) {
+                        currentBuild.description = ([currentBuild.description, 'Published:'] + published).minus(null).join('\n')
+                    }
+                }
+            }
+        }
+    }
+    post {
+        failure {
+            notifyDiscourse(env, 'Konflux gate pipeline failed:', currentBuild.description)
+        }
+    }
+}

--- a/theforeman.org/pipelines/vars/konflux/nightly.groovy
+++ b/theforeman.org/pipelines/vars/konflux/nightly.groovy
@@ -1,0 +1,34 @@
+// Name of the JJB job this vars file feeds (pipelines/release/pipelines/konflux-gate.groovy
+// + pipelines/lib/konflux_gate.groovy are shared across streams, same as
+// katello.groovy is shared across nightly/4.20/4.21 via their own vars files).
+// katello.groovy's trigger-konflux-rebuild stage reads this to know which job to
+// start — kept here instead of hardcoded in the shared katello.groovy, so a future
+// branched stream (e.g. pipelines/vars/konflux/3-19.groovy feeding a
+// konflux-gate-3-19-pipeline job) only needs its own vars file, no katello.groovy
+// change.
+def konflux_gate_job_name = 'konflux-gate-nightly-pipeline'
+
+// Konflux Applications gated by this stream, mapped to the Components bundled in
+// each Application's Snapshot (confirmed against the live cluster: `foreman` is a
+// single Application whose Snapshot carries both foreman-develop and
+// foreman-proxy-develop, not two separate Applications).
+def konflux_gate_applications = [
+    'candlepin': ['candlepin-develop'],
+    'foreman': ['foreman-develop', 'foreman-proxy-develop'],
+    'pulp': ['pulp-develop'],
+]
+
+// Production ReleasePlan per Application. These do not exist yet — they are created
+// by the tenants-config prerequisite MR that splits the current single auto-release
+// ReleasePlan (e.g. release-candlepin-develop-nightly, which today auto-releases
+// straight to quay.io/foreman/<image>:nightly) into a stage variant (kept
+// auto-release, retagged) and this manually-triggered production variant. Update
+// these names once that MR lands.
+def konflux_gate_release_plans = [
+    'candlepin': 'release-candlepin-develop-production',
+    'foreman': 'release-foreman-develop-production',
+    'pulp': 'release-pulp-develop-production',
+]
+
+def snapshot_wait_timeout_minutes = 60
+def release_wait_timeout_minutes = 30

--- a/theforeman.org/yaml/jobs/pipeline/katello-nightly-rpm-pipeline.yaml
+++ b/theforeman.org/yaml/jobs/pipeline/katello-nightly-rpm-pipeline.yaml
@@ -10,6 +10,7 @@
     dsl:
       !include-raw-verbatim:
         - pipelines/vars/katello/nightly.groovy
+        - pipelines/vars/konflux/nightly.groovy
         - pipelines/release/pipelines/katello.groovy
         - pipelines/lib/release.groovy
         - pipelines/lib/ansible.groovy

--- a/theforeman.org/yaml/jobs/pipeline/konflux-gate-nightly-pipeline.yaml
+++ b/theforeman.org/yaml/jobs/pipeline/konflux-gate-nightly-pipeline.yaml
@@ -1,0 +1,28 @@
+- job:
+    name: konflux-gate-nightly-pipeline
+    project-type: pipeline
+    sandbox: true
+    # No `triggers:` block: this job is started explicitly by
+    # katello-nightly-rpm-pipeline's trigger-konflux-rebuild stage via
+    # `build job: 'konflux-gate-nightly-pipeline', parameters: [...]`, not by a
+    # reverse trigger. A reverse trigger can't carry the PREVIOUS_SNAPSHOTS parameter
+    # that capture-konflux-snapshots captures, and without it this job would have to
+    # recompute "previous" itself once started, which races with Konflux's own build
+    # latency (see wait-for-snapshots in konflux-gate.groovy).
+    #
+    # Named "...-nightly-..." (not just "konflux-gate-pipeline") to match the
+    # nightly.groovy vs 3.19.groovy/4.21.groovy convention used by
+    # pipelines/vars/{foreman,katello}/ — the pipeline body
+    # (pipelines/release/pipelines/konflux-gate.groovy) and lib
+    # (pipelines/lib/konflux_gate.groovy) are meant to be reused as-is for a future
+    # branched-version gate (e.g. konflux-gate-3-19-pipeline.yaml including a new
+    # pipelines/vars/konflux/3-19.groovy instead of nightly.groovy).
+    dsl:
+      !include-raw-verbatim:
+        - pipelines/vars/konflux/nightly.groovy
+        - pipelines/release/pipelines/konflux-gate.groovy
+        - pipelines/lib/konflux.groovy
+        - pipelines/lib/konflux_gate.groovy
+        - pipelines/lib/duffy.groovy
+        - pipelines/lib/foreman_infra.groovy
+        - pipelines/lib/ansible.groovy


### PR DESCRIPTION
## Summary

Konflux nightly builds for `candlepin-develop`, `foreman-develop`,
`foreman-proxy-develop` and `pulp-develop` currently auto-release straight to
production quay with no functional testing. This adds `konflux-gate-nightly-pipeline`,
chained after `katello-nightly-rpm-pipeline`, which:

1. Waits for each Konflux Application's Snapshot to update (per-component timeout,
   falls back to the last successfully-released Snapshot on timeout so one broken
   component doesn't block the others).
2. Runs a real `foremanctl`/`forge` install test against the staged images
   (`quay.io/foreman/stage/*`), provisioned directly via Duffy on `ci.theforeman.org`.
3. On pass, creates a Konflux `Release` CR per Application to promote stage → production
   quay, polls it to completion, and records the actual published digest in the build
   description.

## Design decisions

- **Duffy directly on ci.theforeman.org, not delegated through ci.centos.org.** The
  existing `runCicoJob`/`runIndividualCicoJob` path HTTP-triggers a job on the
  centos.org Jenkins for every Duffy-backed test today — an extra hop/failure domain
  not needed here. Draft PR #571 is already moving Duffy test-driving into
  theforeman.org; this follows that direction (`provisionDuffy()`/`duffy_ssh()` drive a
  single `root@duffy_box` SSH session, modeled on
  `centos.org/pipelines/foreman-discovery-image-build.groovy`, not forklift's
  multi-user abstraction). No new centos.org delegation was added.
- **foremanctl/forge, not forklift.** `forge` is what `foreman-oci-images`' own CI
  already uses for this install test. We reuse its VM lifecycle and deploy invocation
  as-is but skip the local `podman build`/`save`/`load` step — Konflux already built and
  pushed the images we're gating, so we only ever pull the real digest-pinned
  `quay.io/foreman/stage/*` refs (see reproduction below). `forge` itself transitively
  pulls the `theforeman.forklift` Ansible collection to manage the VM — that's `forge`'s
  own dependency, not one this PR adds.
- **No fixed-delay/tkn polling for the rebuild trigger.** `katello.groovy` captures each
  Application's "previous" Snapshot *before* triggering the Konflux rebuild
  (`capture-konflux-snapshots`) and passes it to the gate job as a build parameter
  (`PREVIOUS_SNAPSHOTS`) rather than letting the gate job recompute it after starting —
  recomputing there would race with Konflux's own build latency (a fast build could
  already have landed by the time the gate job's first stage runs). Comparing against
  the snapshot name itself already blocks for exactly as long as the real build takes.
- **Release CRs are polled to completion, not fire-and-forget.** Konflux's
  release-service can still fail after the Release CR is accepted (signing, EC policy,
  registry push) — the gate polls `status.conditions[type=Released]` and reads the
  published digest from `status.artifacts.images`, marking the build `UNSTABLE` on
  failure/timeout.
- **Vars-file layout matches the existing `nightly.groovy` vs
  `3.19.groovy`/`4.21.groovy` convention** (`pipelines/vars/{foreman,katello}/`).
  `pipelines/vars/konflux/nightly.groovy` holds develop-stream data;
  `pipelines/release/pipelines/konflux-gate.groovy` and
  `pipelines/lib/konflux_gate.groovy` are stream-agnostic, so a future branched stream
  (e.g. 3.19) only needs a new vars file + job YAML.

## Prerequisite outside this repo

tenants-config needs a production `ReleasePlan` per Application (referenced via
`konflux_gate_release_plans`) that promotes stage → `quay.io/foreman/<image>:nightly`
on manual Release only, replacing today's single auto-release plan. RBAC is already
sufficient — `konflux-bot-0` is bound to `konflux-maintainer-user-actions`, which
already grants full CRUD on `snapshots`/`releases`/`releaseplans`.

## How this was validated locally

`./test theforeman.org` validates JJB rendering only — it never executes the Groovy —
so the actual gate mechanism was reproduced end-to-end by hand against the real latest
Konflux stage images, on a machine with Vagrant/libvirt and `oc` access to the
`theforeman-org-tenant` namespace:

1. Resolved the latest Snapshot per Application and its component image digests:
   ```
   oc get snapshot -n theforeman-org-tenant -l appstudio.openshift.io/application=candlepin \
     --sort-by=.metadata.creationTimestamp -o jsonpath='{.items[-1].metadata.name}'
   # -> candlepin-20260717-042540-000

   oc get snapshot candlepin-20260717-042540-000 -n theforeman-org-tenant \
     -o jsonpath='{range .spec.components[*]}{.name}{"\t"}{.containerImage}{"\n"}{end}'
   # -> candlepin-develop  quay.io/foreman/stage/candlepin@sha256:fd6c46d8ebfade535d636d01e296c5d5c17523d3e51dc0a784394f5218fcfebc
   ```
   (same for `foreman` — which bundles both `foreman-develop` and
   `foreman-proxy-develop` in one Snapshot — and `pulp`).

2. Confirmed the images are pullable without auth (`skopeo inspect docker://...`).

3. Cloned `theforeman/foremanctl` and ran its own setup:
   ```
   git clone https://github.com/theforeman/foremanctl.git
   cd foremanctl
   GITHUB_ACTIONS=true ./setup-environment
   ```

4. Patched `src/vars/images.yml` exactly as `konflux_gate_run_test` does — split each
   digest ref into an `image@sha256` / `<hex>` pair, since the deploy roles only join
   `"{{ x_container_image }}:{{ x_container_tag }}"` and there's no CLI/extra-vars
   override:
   ```diff
   -candlepin_container_image: quay.io/foreman/candlepin
   -candlepin_container_tag: "foreman-{{ container_tag_stream }}"
   -foreman_container_image: quay.io/foreman/foreman
   -foreman_container_tag: "{{ container_tag_stream }}"
   -foreman_proxy_container_image: "quay.io/foreman/foreman-proxy"
   -foreman_proxy_container_tag: "{{ container_tag_stream }}"
   +candlepin_container_image: quay.io/foreman/stage/candlepin@sha256
   +candlepin_container_tag: "fd6c46d8ebfade535d636d01e296c5d5c17523d3e51dc0a784394f5218fcfebc"
   +foreman_container_image: quay.io/foreman/stage/foreman@sha256
   +foreman_container_tag: "17345e73a80fcb251c7c16ae1bc9b57f595b6d48fd05167ae35854319d6d814a"
   +foreman_proxy_container_image: quay.io/foreman/stage/foreman-proxy@sha256
   +foreman_proxy_container_tag: "8453278c895cddae475dad3c7d413f9c8d6b1339590b3104373407e613a7a688"
    postgresql_container_image: quay.io/sclorg/postgresql-16-c10s
    postgresql_container_tag: "latest"
   -pulp_container_image: quay.io/foreman/pulp
   -pulp_container_tag: "foreman-{{ container_tag_stream }}"
   +pulp_container_image: quay.io/foreman/stage/pulp@sha256
   +pulp_container_tag: "9e83fa61b4c6c94d9432766ddffee5e24e38620d3cb24c75973e26792b7617a6"
    valkey_container_image: quay.io/sclorg/valkey-8-c10s
    valkey_container_tag: "latest"
   ```

5. Ran the VM lifecycle and deploy:
   ```
   ./forge vms start --vms "quadlet"
   ./forge setup-repositories
   ./foremanctl deploy --initial-admin-password=changeme --tuning development \
     --add-feature hammer --add-feature foreman-proxy --add-feature remote-execution
   ```
   Result: `PLAY RECAP ... ok=256 changed=160 failed=0`. Confirmed on the VM
   (`vagrant ssh quadlet -- sudo podman images`) that the real stage digests were
   pulled, not tags.

6. Ran the test suite:
   ```
   ./forge test --pytest-args="tests --ignore=tests/flavor --ignore=tests/feature/iop \
     --ignore=tests/backup_test.py --ignore=tests/certificate_bundle_test.py \
     --ignore=tests/feature/foreman/base_test.py \
     --deselect tests/feature/katello/client_test.py::test_foreman_content_view"
   ```
   Result: **270 passed**, including the full `candlepin_test.py` and `pulp_test.py`
   suites, `httpd`/`postgresql`/`valkey`/`foreman_target` health checks. The excluded
   items are documented inline in `konflux_gate_run_test` (pytest module-name collision
   in `tests/flavor`, tests needing `--add-feature iop` or a second Vagrant VM we don't
   provision here, and a few tests with a `./foremanctl`-relative-path bug unrelated to
   image content).

7. Verified `status.conditions`/`status.artifacts.images` shapes and the
   `release.appstudio.openshift.io/snapshot` label used for release idempotency
   directly against a real completed `Release` object on the cluster.

8. `vagrant destroy -f` to tear down.

## Test plan

- [x] `./test theforeman.org` passes (JJB render + `jenkins-lint.py` on all generated
      `config.xml`, including the new/changed jobs).
- [x] Local reproduction above validates the image-substitution mechanism and the full
      deploy+test flow against real Konflux stage images end-to-end.
- [ ] tenants-config MR (production ReleasePlan split) lands — external prerequisite,
      tracked separately.
- [ ] First real run on `ci.theforeman.org` once merged (draft PR pending that).