### PR TITLE
Add EL10 support to nightly pipelines

### DIFF
--- a/theforeman.org/pipelines/vars/candlepin/nightly.groovy
+++ b/theforeman.org/pipelines/vars/candlepin/nightly.groovy
@@ -1,10 +1,13 @@
 def candlepin_version = 'nightly'
 def packaging_branch = 'rpm/develop'
 def candlepin_distros = [
+    'el10',
     'el9'
 ]
 def pipelines = [
     'candlepin': [
+        'centos10-stream',
+        'almalinux10',
         'centos9-stream',
         'almalinux9',
     ]

--- a/theforeman.org/pipelines/vars/foreman/nightly.groovy
+++ b/theforeman.org/pipelines/vars/foreman/nightly.groovy
@@ -8,6 +8,7 @@ def foreman_client_distros = [
     'el8',
 ]
 def foreman_el_releases = [
+    'el10',
     'el9'
 ]
 def foreman_debian_releases = ['bookworm', 'jammy']
@@ -25,10 +26,14 @@ def pipelines_deb = [
 
 def pipelines_el = [
     'install': [
+        'centos10-stream',
+        'almalinux10',
         'centos9-stream',
         'almalinux9',
     ],
     'upgrade': [
+        'centos10-stream',
+        'almalinux10',
         'centos9-stream',
         'almalinux9',
     ]

--- a/theforeman.org/pipelines/vars/katello/nightly.groovy
+++ b/theforeman.org/pipelines/vars/katello/nightly.groovy
@@ -2,14 +2,19 @@ def foreman_version = 'nightly'
 def katello_version = 'nightly'
 def konflux_components = ['candlepin-develop', 'foreman-develop', 'foreman-proxy-develop', 'pulp-develop']
 def foreman_el_releases = [
+    'el10',
     'el9'
 ]
 def pipelines = [
     'install': [
+        'centos10-stream',
+        'almalinux10',
         'centos9-stream',
         'almalinux9',
     ],
     'upgrade': [
+        'centos10-stream',
+        'almalinux10',
         'centos9-stream',
         'almalinux9',
     ]

--- a/theforeman.org/pipelines/vars/pulpcore/nightly.groovy
+++ b/theforeman.org/pipelines/vars/pulpcore/nightly.groovy
@@ -1,8 +1,10 @@
 def pulpcore_version = 'nightly'
-def pulpcore_distros = ['el9']
+def pulpcore_distros = ['el10', 'el9']
 def packaging_branch = 'rpm/develop'
 def pipelines = [
     'pulpcore': [
+        'centos10-stream',
+        'almalinux10',
         'centos9-stream',
         'almalinux9',
     ]


### PR DESCRIPTION
## Summary

- Add `el10` to `foreman_el_releases`, `pulpcore_distros`, and `candlepin_distros` in all nightly vars files (drives staging repo builds, repoclosure, and RPM pushes)
- Add `centos10-stream` and `almalinux10` to the `pipelines` install/upgrade test targets in all nightly vars files (drives forklift-based integration testing)

## When to merge

This should be merged **after** the following prerequisites are in place:

1. **foreman-packaging**, **pulpcore-packaging**, and **candlepin-packaging** repos have been updated to build packages for EL10 (obal/mock/copr targets configured)
2. The companion **forklift PR** (theforeman/forklift#1971) has been merged, so the `almalinux10` box definition and nightly versions entry exist
3. EL10 packages are building successfully in nightly

Merging before the packaging repos are ready will cause the nightly staging pipelines to fail for the el10 targets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)