### PR TITLE
Skip EL10 repoclosure during rebuild

### DIFF
--- a/theforeman.org/pipelines/test/rpm_copr_packaging.groovy
+++ b/theforeman.org/pipelines/test/rpm_copr_packaging.groovy
@@ -156,10 +156,15 @@ pipeline {
             steps {
 
                 script {
+                    def skip_repoclosure_dists = ['el10']
                     for(String package_name: packages_to_build) {
                         repos = copr_repos(package_name)
 
                         for(Map repo: repos) {
+                            if (skip_repoclosure_dists.contains(repo['dist'])) {
+                                echo "Skipping repoclosure for ${package_name} on ${repo['dist']}"
+                                continue
+                            }
                             obal(
                                 action: "repoclosure",
                                 packages: package_name,


### PR DESCRIPTION
## Summary
- Skip repoclosure for EL10 chroots in the RPM packaging PR test pipeline
- EL9 repoclosure continues to run as normal
- Applies to both foreman-packaging and pulpcore-packaging (shared pipeline)

It was too soon to add EL10 repoclosure — the repos are empty while we rebuild all packages, so it fails on every PR.

### To re-enable

Once the EL10 repos are populated enough, remove `el10` from the `skip_repoclosure_dists` list in `pipelines/test/rpm_copr_packaging.groovy`:

```groovy
// Remove this line (or remove 'el10' from the list):
def skip_repoclosure_dists = ['el10']
```