### PR TITLE
Fix EL10 repoclosure skip using if-else instead of continue

### DIFF
--- a/theforeman.org/pipelines/test/rpm_copr_packaging.groovy
+++ b/theforeman.org/pipelines/test/rpm_copr_packaging.groovy
@@ -163,16 +163,16 @@ pipeline {
                         for(Map repo: repos) {
                             if (skip_repoclosure_dists.contains(repo['dist'])) {
                                 echo "Skipping repoclosure for ${package_name} on ${repo['dist']}"
-                                continue
+                            } else {
+                                obal(
+                                    action: "repoclosure",
+                                    packages: package_name,
+                                    extraVars: [
+                                        'repoclosure_check_repos': [repo['url']],
+                                        'repoclosure_target_dist': repo['dist']
+                                    ]
+                                )
                             }
-                            obal(
-                                action: "repoclosure",
-                                packages: package_name,
-                                extraVars: [
-                                    'repoclosure_check_repos': [repo['url']],
-                                    'repoclosure_target_dist': repo['dist']
-                                ]
-                            )
                         }
                     }
                 }


### PR DESCRIPTION
## Summary
- The `continue` keyword does not work correctly in Jenkins CPS-transformed Groovy for-each loops
- Replace with an if-else block so the EL10 repoclosure skip actually takes effect
- Without this fix, EL10 rebuild PRs fail on repoclosure despite the skip list