### PR TITLE
Fix GString comparison bug in convert_to_dist

### DIFF
--- a/theforeman.org/pipelines/lib/copr.groovy
+++ b/theforeman.org/pipelines/lib/copr.groovy
@@ -46,5 +46,5 @@ def convert_to_dist(chroot) {
     os = chroot_parts[0..-3].join('-')
     version = chroot_parts[-2].replace('.', '')
 
-    return "${family_map[os]}${version}"
+    return "${family_map[os]}${version}".toString()
 }


### PR DESCRIPTION
## Summary

`convert_to_dist()` returns a GString (Groovy interpolated string) via `"${family_map[os]}${version}"`, but `skip_repoclosure_dists` in the pipeline contains plain Strings. `ArrayList.contains()` uses `.equals()`, and in Groovy `String.equals(GString)` returns `false` even when the content is identical.

This caused the EL10 repoclosure skip logic (added in #592) to never fire — the condition was always false regardless of the actual dist value.

Adding `.toString()` to the return value ensures a plain String is returned so the `contains()` check works correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)