### PR TITLE
add Debian 13 to install and publish pipelines

### DIFF
--- a/theforeman.org/pipelines/vars/foreman/nightly.groovy
+++ b/theforeman.org/pipelines/vars/foreman/nightly.groovy
@@ -10,11 +10,12 @@ def foreman_client_distros = [
 def foreman_el_releases = [
     'el9'
 ]
-def foreman_debian_releases = ['bookworm', 'jammy']
+def foreman_debian_releases = ['bookworm', 'jammy', 'trixie']
 
 def pipelines_deb = [
     'install': [
         'debian12',
+        'debian13',
         'ubuntu2204'
     ],
     'upgrade': [


### PR DESCRIPTION
upgrades can be done once at least one Foreman release is available on Debian 13