### PR TITLE
enable foreman repos on the duffy box

### DIFF
--- a/centos.org/pipelines/lib/foremanDuffyJob.groovy
+++ b/centos.org/pipelines/lib/foremanDuffyJob.groovy
@@ -26,6 +26,8 @@ pipeline {
         stage('Provision Node') {
             steps {
                 provisionDuffy()
+
+                duffy_ssh('dnf install -y https://yum.theforeman.org/nightly/el9/x86_64/foreman-release.rpm', 'duffy_box', './')
             }
         }
         stage('Install Pipeline Requirements') {


### PR DESCRIPTION
this is required for obtaining newer ansible-core, which we need to talk to Ubuntu 24.04, EL10 and similar machines