### PR TITLE
Remove EL10 from nightly upgrade pipelines

### DIFF
--- a/theforeman.org/pipelines/vars/candlepin/nightly.groovy
+++ b/theforeman.org/pipelines/vars/candlepin/nightly.groovy
@@ -1,10 +1,13 @@
 def candlepin_version = 'nightly'
 def packaging_branch = 'rpm/develop'
 def candlepin_distros = [
+    'el10',
     'el9'
 ]
 def pipelines = [
     'candlepin': [
+        'centos10-stream',
+        'almalinux10',
         'centos9-stream',
         'almalinux9',
     ]

--- a/theforeman.org/pipelines/vars/foreman/nightly.groovy
+++ b/theforeman.org/pipelines/vars/foreman/nightly.groovy
@@ -8,6 +8,7 @@ def foreman_client_distros = [
     'el8',
 ]
 def foreman_el_releases = [
+    'el10',
     'el9'
 ]
 def foreman_debian_releases = ['bookworm', 'jammy']
@@ -25,10 +26,14 @@ def pipelines_deb = [
 
 def pipelines_el = [
     'install': [
+        'centos10-stream',
+        'almalinux10',
         'centos9-stream',
         'almalinux9',
     ],
     'upgrade': [
+        'centos10-stream',
+        'almalinux10',
         'centos9-stream',
         'almalinux9',
     ]

--- a/theforeman.org/pipelines/vars/foreman/nightly.groovy
+++ b/theforeman.org/pipelines/vars/foreman/nightly.groovy
@@ -32,8 +32,6 @@ def pipelines_el = [
         'almalinux9',
     ],
     'upgrade': [
-        'centos10-stream',
-        'almalinux10',
         'centos9-stream',
         'almalinux9',
     ]

--- a/theforeman.org/pipelines/vars/katello/nightly.groovy
+++ b/theforeman.org/pipelines/vars/katello/nightly.groovy
@@ -2,14 +2,19 @@ def foreman_version = 'nightly'
 def katello_version = 'nightly'
 def konflux_components = ['candlepin-develop', 'foreman-develop', 'foreman-proxy-develop', 'pulp-develop']
 def foreman_el_releases = [
+    'el10',
     'el9'
 ]
 def pipelines = [
     'install': [
+        'centos10-stream',
+        'almalinux10',
         'centos9-stream',
         'almalinux9',
     ],
     'upgrade': [
+        'centos10-stream',
+        'almalinux10',
         'centos9-stream',
         'almalinux9',
     ]

--- a/theforeman.org/pipelines/vars/katello/nightly.groovy
+++ b/theforeman.org/pipelines/vars/katello/nightly.groovy
@@ -13,8 +13,6 @@ def pipelines = [
         'almalinux9',
     ],
     'upgrade': [
-        'centos10-stream',
-        'almalinux10',
         'centos9-stream',
         'almalinux9',
     ]

--- a/theforeman.org/pipelines/vars/pulpcore/nightly.groovy
+++ b/theforeman.org/pipelines/vars/pulpcore/nightly.groovy
@@ -1,8 +1,10 @@
 def pulpcore_version = 'nightly'
-def pulpcore_distros = ['el9']
+def pulpcore_distros = ['el10', 'el9']
 def packaging_branch = 'rpm/develop'
 def pipelines = [
     'pulpcore': [
+        'centos10-stream',
+        'almalinux10',
         'centos9-stream',
         'almalinux9',
     ]


### PR DESCRIPTION
## Summary
- Remove `centos10-stream` and `almalinux10` from the upgrade lists in foreman and katello nightly pipeline vars
- EL10 upgrades are not yet supported, but EL10 installs and EL9 upgrades continue to run as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)