### PR TITLE
Split nightly RPM pipelines into separate EL9 and EL10 jobs

### DIFF
--- a/centos.org/jobs/candlepin-pipelines.yml
+++ b/centos.org/jobs/candlepin-pipelines.yml
@@ -10,6 +10,7 @@
       - '4.6'
       - '4.7'
       - '4.8'
-      - nightly
+      - '5.0'
+      - nightly-el9
     type:
       - candlepin

--- a/theforeman.org/pipelines/release/pipelines/candlepin.groovy
+++ b/theforeman.org/pipelines/release/pipelines/candlepin.groovy
@@ -11,7 +11,7 @@ pipeline {
     stages {
         stage('staging-build-repository') {
             when {
-                expression { candlepin_version == 'nightly' }
+                expression { candlepin_version.startsWith('nightly') }
             }
             steps {
                 git url: "https://github.com/theforeman/theforeman-rel-eng", poll: false
@@ -25,7 +25,7 @@ pipeline {
         }
         stage('staging-copy-repository') {
             when {
-                expression { candlepin_version == 'nightly' }
+                expression { candlepin_version.startsWith('nightly') }
             }
             steps {
                 script {
@@ -48,6 +48,9 @@ pipeline {
         stage('staging-test') {
             agent any
 
+            when {
+                expression { candlepin_version != 'nightly-el10' }
+            }
             steps {
                 script {
                     runDuffyPipeline('candlepin-rpm', candlepin_version)

--- a/theforeman.org/pipelines/release/pipelines/foreman-rpm.groovy
+++ b/theforeman.org/pipelines/release/pipelines/foreman-rpm.groovy
@@ -48,6 +48,9 @@ pipeline {
         stage('staging-test') {
             agent any
 
+            when {
+                expression { foreman_el_releases.contains('el9') }
+            }
             steps {
                 script {
                     runDuffyPipeline('foreman-rpm', foreman_version)

--- a/theforeman.org/pipelines/release/pipelines/katello.groovy
+++ b/theforeman.org/pipelines/release/pipelines/katello.groovy
@@ -48,6 +48,9 @@ pipeline {
         stage('staging-test') {
             agent any
 
+            when {
+                expression { foreman_el_releases.contains('el9') }
+            }
             steps {
                 script {
                     runDuffyPipeline('katello-rpm', katello_version)

--- a/theforeman.org/pipelines/vars/candlepin/5.0.groovy
+++ b/theforeman.org/pipelines/vars/candlepin/5.0.groovy
@@ -1,0 +1,11 @@
+def candlepin_version = '5.0'
+def packaging_branch = 'rpm/5.0'
+def candlepin_distros = [
+    'el10'
+]
+def pipelines = [
+    'candlepin': [
+        'centos10-stream',
+        'almalinux10',
+    ]
+]

--- a/theforeman.org/pipelines/vars/candlepin/nightly-el10.groovy
+++ b/theforeman.org/pipelines/vars/candlepin/nightly-el10.groovy
@@ -1,14 +1,11 @@
-def candlepin_version = 'nightly'
+def candlepin_version = 'nightly-el10'
 def packaging_branch = 'rpm/develop'
 def candlepin_distros = [
-    'el10',
-    'el9'
+    'el10'
 ]
 def pipelines = [
     'candlepin': [
         'centos10-stream',
         'almalinux10',
-        'centos9-stream',
-        'almalinux9',
     ]
 ]

--- a/theforeman.org/pipelines/vars/candlepin/nightly-el9.groovy
+++ b/theforeman.org/pipelines/vars/candlepin/nightly-el9.groovy
@@ -1,0 +1,11 @@
+def candlepin_version = 'nightly-el9'
+def packaging_branch = 'rpm/4.8'
+def candlepin_distros = [
+    'el9'
+]
+def pipelines = [
+    'candlepin': [
+        'centos9-stream',
+        'almalinux9',
+    ]
+]

--- a/theforeman.org/pipelines/vars/foreman/nightly-el10.groovy
+++ b/theforeman.org/pipelines/vars/foreman/nightly-el10.groovy
@@ -1,0 +1,10 @@
+def foreman_version = 'nightly'
+def git_branch = "develop"
+def ruby_version = '3.0.4'
+
+def foreman_client_distros = [
+    'el10',
+]
+def foreman_el_releases = [
+    'el10'
+]

--- a/theforeman.org/pipelines/vars/foreman/nightly-el9.groovy
+++ b/theforeman.org/pipelines/vars/foreman/nightly-el9.groovy
@@ -1,0 +1,40 @@
+def foreman_version = 'nightly'
+def git_branch = "develop"
+def ruby_version = '3.0.4'
+
+def foreman_client_distros = [
+    'el9',
+    'el8',
+]
+def foreman_el_releases = [
+    'el9'
+]
+def foreman_debian_releases = ['bookworm', 'jammy', 'noble']
+
+def pipelines_deb = [
+    'install': [
+        'debian12',
+        'ubuntu2204',
+        'ubuntu2404'
+    ],
+    'upgrade': [
+        'debian12',
+        'ubuntu2204'
+    ]
+]
+
+def pipelines_el = [
+    'install': [
+        'centos9-stream',
+        'almalinux9',
+    ],
+    'upgrade': [
+        'centos9-stream',
+        'almalinux9',
+    ]
+]
+
+def pipelines = [
+    'install': pipelines_deb['install'] + pipelines_el['install'],
+    'upgrade': pipelines_deb['upgrade'] + pipelines_el['upgrade'],
+]

--- a/theforeman.org/pipelines/vars/katello/nightly-el10.groovy
+++ b/theforeman.org/pipelines/vars/katello/nightly-el10.groovy
@@ -1,0 +1,6 @@
+def foreman_version = 'nightly'
+def katello_version = 'nightly'
+def konflux_components = ['candlepin-develop', 'foreman-develop', 'foreman-proxy-develop', 'pulp-develop']
+def foreman_el_releases = [
+    'el10'
+]

--- a/theforeman.org/pipelines/vars/katello/nightly-el9.groovy
+++ b/theforeman.org/pipelines/vars/katello/nightly-el9.groovy
@@ -1,0 +1,15 @@
+def foreman_version = 'nightly'
+def katello_version = 'nightly'
+def foreman_el_releases = [
+    'el9'
+]
+def pipelines = [
+    'install': [
+        'centos9-stream',
+        'almalinux9',
+    ],
+    'upgrade': [
+        'centos9-stream',
+        'almalinux9',
+    ]
+]

--- a/theforeman.org/yaml/includes/candlepin_versions.yaml.inc
+++ b/theforeman.org/yaml/includes/candlepin_versions.yaml.inc
@@ -1,4 +1,6 @@
-- 'nightly'
+- 'nightly-el9'
+- 'nightly-el10'
 - '4.6'
 - '4.7'
 - '4.8'
+- '5.0'

--- a/theforeman.org/yaml/jobs/pipeline/foreman-nightly-el10-rpm-pipeline.yaml
+++ b/theforeman.org/yaml/jobs/pipeline/foreman-nightly-el10-rpm-pipeline.yaml
@@ -1,19 +1,15 @@
 - job:
-    name: katello-nightly-rpm-pipeline
+    name: foreman-nightly-el10-rpm-pipeline
     project-type: pipeline
     sandbox: true
     triggers:
-      - reverse:
-          jobs:
-            - foreman-nightly-rpm-pipeline
-          result: success
+      - timed: 'H 1 * * *'
     dsl:
       !include-raw-verbatim:
-        - pipelines/vars/katello/nightly.groovy
-        - pipelines/release/pipelines/katello.groovy
+        - pipelines/vars/foreman/nightly-el10.groovy
+        - pipelines/release/pipelines/foreman-rpm.groovy
         - pipelines/lib/release.groovy
         - pipelines/lib/ansible.groovy
         - pipelines/lib/foreman_infra.groovy
         - pipelines/lib/packaging.groovy
         - pipelines/lib/obal.groovy
-        - pipelines/lib/konflux.groovy

--- a/theforeman.org/yaml/jobs/pipeline/foreman-nightly-el9-rpm-pipeline.yaml
+++ b/theforeman.org/yaml/jobs/pipeline/foreman-nightly-el9-rpm-pipeline.yaml
@@ -1,0 +1,15 @@
+- job:
+    name: foreman-nightly-el9-rpm-pipeline
+    project-type: pipeline
+    sandbox: true
+    triggers:
+      - timed: 'H 1 * * *'
+    dsl:
+      !include-raw-verbatim:
+        - pipelines/vars/foreman/nightly-el9.groovy
+        - pipelines/release/pipelines/foreman-rpm.groovy
+        - pipelines/lib/release.groovy
+        - pipelines/lib/ansible.groovy
+        - pipelines/lib/foreman_infra.groovy
+        - pipelines/lib/packaging.groovy
+        - pipelines/lib/obal.groovy

--- a/theforeman.org/yaml/jobs/pipeline/katello-nightly-el10-rpm-pipeline.yaml
+++ b/theforeman.org/yaml/jobs/pipeline/katello-nightly-el10-rpm-pipeline.yaml
@@ -1,0 +1,19 @@
+- job:
+    name: katello-nightly-el10-rpm-pipeline
+    project-type: pipeline
+    sandbox: true
+    triggers:
+      - reverse:
+          jobs:
+            - foreman-nightly-el10-rpm-pipeline
+          result: success
+    dsl:
+      !include-raw-verbatim:
+        - pipelines/vars/katello/nightly-el10.groovy
+        - pipelines/release/pipelines/katello.groovy
+        - pipelines/lib/release.groovy
+        - pipelines/lib/ansible.groovy
+        - pipelines/lib/foreman_infra.groovy
+        - pipelines/lib/packaging.groovy
+        - pipelines/lib/obal.groovy
+        - pipelines/lib/konflux.groovy

--- a/theforeman.org/yaml/jobs/pipeline/katello-nightly-el9-rpm-pipeline.yaml
+++ b/theforeman.org/yaml/jobs/pipeline/katello-nightly-el9-rpm-pipeline.yaml
@@ -1,15 +1,19 @@
 - job:
-    name: foreman-nightly-rpm-pipeline
+    name: katello-nightly-el9-rpm-pipeline
     project-type: pipeline
     sandbox: true
     triggers:
-      - timed: 'H 1 * * *'
+      - reverse:
+          jobs:
+            - foreman-nightly-el9-rpm-pipeline
+          result: success
     dsl:
       !include-raw-verbatim:
-        - pipelines/vars/foreman/nightly.groovy
-        - pipelines/release/pipelines/foreman-rpm.groovy
+        - pipelines/vars/katello/nightly-el9.groovy
+        - pipelines/release/pipelines/katello.groovy
         - pipelines/lib/release.groovy
         - pipelines/lib/ansible.groovy
         - pipelines/lib/foreman_infra.groovy
         - pipelines/lib/packaging.groovy
         - pipelines/lib/obal.groovy
+        - pipelines/lib/konflux.groovy

--- a/theforeman.org/yaml/jobs/pipeline/luna-nightly-el9-rpm-pipeline.yaml
+++ b/theforeman.org/yaml/jobs/pipeline/luna-nightly-el9-rpm-pipeline.yaml
@@ -1,15 +1,15 @@
 - job:
-    name: luna-nightly-rpm-pipeline
+    name: luna-nightly-el9-rpm-pipeline
     project-type: pipeline
     sandbox: true
     triggers:
       - reverse:
           jobs:
-            - katello-nightly-rpm-pipeline
+            - katello-nightly-el9-rpm-pipeline
           result: success
     dsl:
       !include-raw-verbatim:
-        - pipelines/vars/katello/nightly.groovy
+        - pipelines/vars/katello/nightly-el9.groovy
         - pipelines/release/pipelines/luna.groovy
         - pipelines/lib/ansible.groovy
         - pipelines/lib/foreman_infra.groovy


### PR DESCRIPTION
## Summary
- Candlepin 5.0 is EL10-only while EL9 remains on Candlepin 4.8, requiring separate nightly pipelines per EL version so each pulls from the correct packaging branch
- Add candlepin 5.0 release pipeline (rpm/5.0, el10-only)
- Split candlepin nightly into nightly-el9 (rpm/4.8) and nightly-el10 (rpm/develop)
- Split foreman, katello, and luna nightly RPM pipelines with trigger chains matched by EL version: foreman-el9 → katello-el9 → luna-el9, and foreman-el10 → katello-el10
- Luna is EL9-only since it only runs Duffy tests
- Staging-test (Duffy) stage is skipped for EL10 pipelines to unblock getting containers built; install tests for EL10 will be added later

🤖 Generated with [Claude Code](https://claude.com/claude-code)