### PR TITLE
Enable EL10 repoclosure for Copr package builds

### DIFF
--- a/theforeman.org/pipelines/test/rpm_copr_packaging.groovy
+++ b/theforeman.org/pipelines/test/rpm_copr_packaging.groovy
@@ -156,23 +156,18 @@ pipeline {
             steps {
 
                 script {
-                    def skip_repoclosure_dists = ['el10']
                     for(String package_name: packages_to_build) {
                         repos = copr_repos(package_name)
 
                         for(Map repo: repos) {
-                            if (skip_repoclosure_dists.contains(repo['dist'])) {
-                                echo "Skipping repoclosure for ${package_name} on ${repo['dist']}"
-                            } else {
-                                obal(
-                                    action: "repoclosure",
-                                    packages: package_name,
-                                    extraVars: [
-                                        'repoclosure_check_repos': [repo['url']],
-                                        'repoclosure_target_dist': repo['dist']
-                                    ]
-                                )
-                            }
+                            obal(
+                                action: "repoclosure",
+                                packages: package_name,
+                                extraVars: [
+                                    'repoclosure_check_repos': [repo['url']],
+                                    'repoclosure_target_dist': repo['dist']
+                                ]
+                            )
                         }
                     }
                 }


### PR DESCRIPTION
## Summary
- Remove the `skip_repoclosure_dists` exclusion for EL10 in the Copr packaging pipeline so repoclosure runs for EL10 packages the same as other distros

🤖 Generated with [Claude Code](https://claude.com/claude-code)