### PR TITLE
Add trixie to Foreman deb release pipelines

### DIFF
--- a/theforeman.org/pipelines/vars/foreman/5.0.groovy
+++ b/theforeman.org/pipelines/vars/foreman/5.0.groovy
@@ -11,7 +11,7 @@ def foreman_el_releases = [
     'el10',
     'el9'
 ]
-def foreman_debian_releases = ['bookworm', 'jammy', 'noble']
+def foreman_debian_releases = ['bookworm', 'trixie', 'jammy', 'noble']
 
 def pipelines_deb = [
     'install': [

--- a/theforeman.org/pipelines/vars/foreman/nightly.groovy
+++ b/theforeman.org/pipelines/vars/foreman/nightly.groovy
@@ -11,7 +11,7 @@ def foreman_el_releases = [
     'el10',
     'el9'
 ]
-def foreman_debian_releases = ['bookworm', 'jammy', 'noble']
+def foreman_debian_releases = ['bookworm', 'trixie', 'jammy', 'noble']
 
 def pipelines_deb = [
     'install': [


### PR DESCRIPTION
## Summary
Trixie (Debian 13) was added to foreman-packaging but was never added to the pipeline vars, so trixie packages have never been built or published for nightly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)